### PR TITLE
Rewire-grid: - Fix for firefox line-height calculation of fractional …

### DIFF
--- a/examples/src/Application.tsx
+++ b/examples/src/Application.tsx
@@ -587,7 +587,7 @@ const _Home = (props: any) => <Observe render={() => (
           <Typography style={{margin: 16}}>Are you sure you want to do this crazy shit?</Typography>
         </DialogView>
         <div style={{overflow: 'auto', padding: 10, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center'}}>
-          <div>
+          <div style={{marginBottom: '10px'}}>
             <Button style={{marginRight: '15px'}} variant='contained' onClick={() => grid.addRow({id: 'newRow-' + Math.random() * 2000, 'column2': 'RC 2-1', 'column3': 'RC 3-1', options: {allowMergeColumns: true}})}>Add Row</Button>
             <Button style={{marginRight: '15px'}} variant='contained' onClick={() => grid.removeRow(grid.dataRowsByPosition[grid.dataRowsByPosition.length - 1].id)}>Remove Row</Button>
             <Button style={{marginRight: '15px'}} variant='contained' onClick={() => grid.dataRowsByPosition[0].cells['numberColumn'].value = 1337}>Change Number Cell Value</Button>

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.0-beta.73",
+  "version": "1.0.0-beta.77",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.0-beta.73",
+  "version": "1.0.0-beta.77",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.0-beta.73",
+  "version": "1.0.0-beta.77",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/worksight/rewire",
   "dependencies": {
     "is": "^3.2.1",
-    "rewire-core": "^1.0.0-beta.73"
+    "rewire-core": "^1.0.0-beta.77"
   }
 }

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.0-beta.73",
+  "version": "1.0.0-beta.77",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",
@@ -28,8 +28,8 @@
     "nanoid": "^1.2.3",
     "react": "^16.4.2",
     "resize-observer-polyfill": "^1.5.0",
-    "rewire-common": "^1.0.0-beta.73",
-    "rewire-core": "^1.0.0-beta.73",
-    "rewire-ui": "^1.0.0-beta.73"
+    "rewire-common": "^1.0.0-beta.77",
+    "rewire-core": "^1.0.0-beta.77",
+    "rewire-ui": "^1.0.0-beta.77"
   }
 }

--- a/packages/rewire-grid/src/components/Cell.tsx
+++ b/packages/rewire-grid/src/components/Cell.tsx
@@ -42,7 +42,6 @@ const styles = (theme: Theme) => ({
     alignItems: 'stretch',
     height: '100%',
     width: '100%',
-    lineHeight: `calc(2 * ${theme.fontSizes.body})`,
   },
   cellInnerContainer: {
     overflow: 'hidden',
@@ -178,10 +177,6 @@ class Cell extends React.PureComponent<CellProps, {}> {
     //   this.element.focus();
     // }, 0);
     this.element.focus();
-  }
-
-  setFocusFromMouse(set: boolean) {
-    this.setFocus(set);
   }
 
   handleDoubleClick = (evt: React.MouseEvent<any>) => {
@@ -367,7 +362,7 @@ class Cell extends React.PureComponent<CellProps, {}> {
     }
 
     this.grid.selectCellsTo(this.cell, evt.ctrlKey);
-    this.setFocusFromMouse(true);
+    this.setFocus(true);
   }
 
   handleClick = (evt: React.MouseEvent<any>) => {
@@ -393,7 +388,7 @@ class Cell extends React.PureComponent<CellProps, {}> {
     }
 
     evt.stopPropagation();
-    this.setFocusFromMouse(true);
+    this.setFocus(true);
   }
 
   handleFocus = (evt: React.FocusEvent<any>) => {
@@ -606,7 +601,7 @@ class Cell extends React.PureComponent<CellProps, {}> {
       let rowSpan = cell.rowSpan;
 
       let innerCell =
-        <div className={classes.cellContainer}>
+        <div className={classNames(classes.cellContainer, 'cellContainer')}>
           <div className={cellInnerContainerClasses}>
             {this.renderCell()}
           </div>

--- a/packages/rewire-grid/src/components/Grid.tsx
+++ b/packages/rewire-grid/src/components/Grid.tsx
@@ -210,90 +210,111 @@ export default class Grid extends React.PureComponent<IGridProps> {
   }
 }
 
-const styles = (theme: Theme) => ({
-  leftLabels: {
-    '& tr, & tr.alt': {
-      backgroundColor: theme.palette.leftLabelBackground.main,
-    },
-  },
-  cornerLabels: {
-    borderColor: theme.palette.headerBorder.main,
-    backgroundColor: theme.palette.headerBackground.main,
-  },
-  topLabels: {
-    fontSize: theme.fontSizes.header,
-    color: theme.palette.headerText.main,
-    borderColor: theme.palette.headerBorder.main,
-    backgroundColor: theme.palette.headerBackground.main,
-    '& div.sort': {
-      '&:after': {
-        color: theme.palette.headerText.main,
+const styles = (theme: Theme) => {
+  // firefox consideration for fractional pixels issue
+  let bodyFontSizeDigits = Number.parseFloat(theme.fontSizes.body.replace(/[^\d.-]/g, ''));
+  let bodyFontSizeUnit   = theme.fontSizes.body.replace(/[\d.-]/g, '');
+  if (bodyFontSizeUnit === 'rem') {
+    let rootElement = document.documentElement;
+    if (rootElement) {
+      let rootElementFontSize = window.getComputedStyle(rootElement).getPropertyValue('font-size');
+      bodyFontSizeDigits     *= Number.parseFloat(rootElementFontSize.replace(/[^\d.-]/g, ''));
+    }
+  } else if (bodyFontSizeUnit === 'em') {
+    bodyFontSizeDigits *= theme.typography.fontSize;
+  }
+
+  let cellContainerLineHeight = `${2 * Math.round(bodyFontSizeDigits)}px`;
+
+  let styleObj = {
+    leftLabels: {
+      '& tr, & tr.alt': {
+        backgroundColor: theme.palette.leftLabelBackground.main,
       },
     },
-    '& tr': {
-      height: `calc(2.4 * ${theme.fontSizes.header})`,
-    },
-    '& th': {
+    cornerLabels: {
       borderColor: theme.palette.headerBorder.main,
-      padding: '0px 7px',
+      backgroundColor: theme.palette.headerBackground.main,
     },
-  },
-  wsGrid: {
-    color: theme.palette.gridText.main,
-    borderColor: theme.palette.gridBorder.main,
-    backgroundColor: theme.palette.gridBackground.main,
-    '& tr.selected td, & tr.selected th': {
-      '&.selected': {
-        borderRightColor: theme.palette.gridBorderSelected.main,
-        borderBottomColor: theme.palette.gridBorderSelected.main,
-        backgroundColor: theme.palette.cellSelectedBackground.main,
+    topLabels: {
+      fontSize: theme.fontSizes.header,
+      color: theme.palette.headerText.main,
+      borderColor: theme.palette.headerBorder.main,
+      backgroundColor: theme.palette.headerBackground.main,
+      '& div.sort': {
+        '&:after': {
+          color: theme.palette.headerText.main,
+        },
       },
-      '&.selectedTopMost': {
-        borderTopColor: theme.palette.cellOutline.main,
+      '& tr': {
+        height: `calc(2.4 * ${theme.fontSizes.header})`,
       },
-      '&.selectedRightMost': {
-        borderRightColor: theme.palette.cellOutline.main,
-      },
-      '&.selectedBottomMost': {
-        borderBottomColor: theme.palette.cellOutline.main,
-      },
-      '&.selectedLeftMost': {
-        borderLeftColor: theme.palette.cellOutline.main,
+      '& th': {
+        borderColor: theme.palette.headerBorder.main,
+        padding: '0px 7px',
       },
     },
-    '& td, & .left-labels td.selected': {
-      borderTopColor: 'transparent',
-      borderRightColor: theme.palette.gridBorder.main,
-      borderBottomColor: theme.palette.gridBorder.main,
-      borderLeftColor: 'transparent',
+    wsGrid: {
+      color: theme.palette.gridText.main,
+      borderColor: theme.palette.gridBorder.main,
+      backgroundColor: theme.palette.gridBackground.main,
+      '& tr.selected td, & tr.selected th': {
+        '&.selected': {
+          borderRightColor: theme.palette.gridBorderSelected.main,
+          borderBottomColor: theme.palette.gridBorderSelected.main,
+          backgroundColor: theme.palette.cellSelectedBackground.main,
+        },
+        '&.selectedTopMost': {
+          borderTopColor: theme.palette.cellOutline.main,
+        },
+        '&.selectedRightMost': {
+          borderRightColor: theme.palette.cellOutline.main,
+        },
+        '&.selectedBottomMost': {
+          borderBottomColor: theme.palette.cellOutline.main,
+        },
+        '&.selectedLeftMost': {
+          borderLeftColor: theme.palette.cellOutline.main,
+        },
+      },
+      '& td, & .left-labels td.selected': {
+        borderTopColor: 'transparent',
+        borderRightColor: theme.palette.gridBorder.main,
+        borderBottomColor: theme.palette.gridBorder.main,
+        borderLeftColor: 'transparent',
+        '& .cellContainer': {
+          lineHeight: cellContainerLineHeight,
+        },
+      },
+      '& th': {
+        borderTopColor: 'transparent',
+        borderRightColor: theme.palette.headerBorder.main,
+        borderBottomColor: theme.palette.headerBorder.main,
+        borderLeftColor: 'transparent',
+      },
     },
-    '& th': {
-      borderTopColor: 'transparent',
-      borderRightColor: theme.palette.headerBorder.main,
-      borderBottomColor: theme.palette.headerBorder.main,
-      borderLeftColor: 'transparent',
+    gridContent: {
+      '& tr.selected': {
+        backgroundColor: theme.palette.rowSelectedBackground.main,
+        color: theme.palette.rowSelectedText.main,
+        '& td': {
+          borderRightColor: theme.palette.rowSelectedBorder.main,
+          borderBottomColor: theme.palette.rowSelectedBorder.main,
+        }
+      },
+      '& tr.alt': {
+        backgroundColor: theme.palette.rowStripedBackground.main,
+      },
+      '& tr.alt.selected': {
+        backgroundColor: theme.palette.rowStripedSelectedBackground.main,
+      },
     },
-  },
-  gridContent: {
-    '& tr.selected': {
-      backgroundColor: theme.palette.rowSelectedBackground.main,
-      color: theme.palette.rowSelectedText.main,
-      '& td': {
-        borderRightColor: theme.palette.rowSelectedBorder.main,
-        borderBottomColor: theme.palette.rowSelectedBorder.main,
-      }
+    gridScroll: {
+      fontSize: theme.fontSizes.body,
     },
-    '& tr.alt': {
-      backgroundColor: theme.palette.rowStripedBackground.main,
-    },
-    '& tr.alt.selected': {
-      backgroundColor: theme.palette.rowStripedSelectedBackground.main,
-    },
-  },
-  gridScroll: {
-    fontSize: theme.fontSizes.body,
-  },
-});
+  };
+  return styleObj;
+};
 
 type GridProps = WithStyle<ReturnType<typeof styles>, IGridProps>;
 
@@ -447,7 +468,7 @@ const GridInternal = withStyles(styles, class extends React.PureComponent<GridPr
         <table role='grid' ref={(c) => this._gridFixed = c as HTMLTableElement} style={{width: this.props.grid.fixedWidth}}>
           {this.renderColumnGroups(true)}
           <tbody role='rowgroup'>
-            {this.props.grid.rows.map((row, index) => <Row key={row.id} row={row} fixedRowElements={this._fixedRowElements} Cell={Cell} columns={this.props.grid.fixedColumns} isFixedRow={true} index={index} visibleColumns={visibleColumns} className={((index % 2) === 1) ? 'alt' : ''} />)}
+            {this.props.grid.rows.map((row, index) => <Row key={row.id} row={row} fixedRowElements={this._fixedRowElements} Cell={Cell} columns={this.props.grid.fixedColumns} isFixedColumnsRow={true} index={index} visibleColumns={visibleColumns} className={((index % 2) === 1) ? 'alt' : ''} />)}
           </tbody>
         </table>
       </div>

--- a/packages/rewire-grid/src/components/Row.tsx
+++ b/packages/rewire-grid/src/components/Row.tsx
@@ -16,15 +16,15 @@ import {Theme}                 from '@material-ui/core/styles';
 import {WithStyle, withStyles} from 'rewire-ui';
 
 export interface IRowProps {
-  row              : IRow;
-  columns          : IColumn[];
-  Cell             : React.ComponentClass<any>;
-  rowElements?     : {[s: string]: HTMLTableRowElement};
-  fixedRowElements?: {[s: string]: HTMLTableRowElement};
-  isFixedRow?      : boolean;
-  index            : number;
-  visibleColumns   : number;
-  className?       : string;
+  row               : IRow;
+  columns           : IColumn[];
+  Cell              : React.ComponentClass<any>;
+  rowElements?      : {[s: string]: HTMLTableRowElement};
+  fixedRowElements? : {[s: string]: HTMLTableRowElement};
+  isFixedColumnsRow?: boolean;
+  index             : number;
+  visibleColumns    : number;
+  className?        : string;
 }
 
 const styles = (theme: Theme) => {
@@ -81,19 +81,19 @@ const Row = withStyles(styles, class extends PureComponent<RowProps, {}> {
       return;
     }
 
-    let rElements = this.props.isFixedRow ? this.props.fixedRowElements : this.props.rowElements;
+    let rElements = this.props.isFixedColumnsRow ? this.props.fixedRowElements : this.props.rowElements;
     if (rElements) {
       delete rElements[this.props.row.id];
     }
 
-    if (!this.props.isFixedRow && this.elementResizeObserver) {
+    if (!this.props.isFixedColumnsRow && this.elementResizeObserver) {
       this.elementResizeObserver.disconnect();
       delete this.elementResizeObserver;
     }
   }
 
   componentDidMount() {
-    if (!this.element || this.props.isFixedRow || isGroupRow(this.props.row)) {
+    if (!this.element || this.props.isFixedColumnsRow || isGroupRow(this.props.row)) {
       return;
     }
 
@@ -149,7 +149,7 @@ const Row = withStyles(styles, class extends PureComponent<RowProps, {}> {
     className     = classNames(className, this.props.row.visible ? this.props.classes.visible : this.props.classes.notVisible + ' notVisible');
 
     let ref: ((node: any) => any) | undefined = undefined;
-    let rElements = this.props.isFixedRow ? this.props.fixedRowElements : this.props.rowElements;
+    let rElements = this.props.isFixedColumnsRow ? this.props.fixedRowElements : this.props.rowElements;
     if (rElements) {
       ref = (rowElement: any) => {
         this.element = rowElement;
@@ -167,7 +167,7 @@ const Row = withStyles(styles, class extends PureComponent<RowProps, {}> {
   renderChildRows(groupRow: IGroupRow): React.ReactNode[] | null {
     // if (!groupRow.expanded) return null;
 
-    return groupRow.rows.map((r, idx) => <Row key={r.id} row={r} rowElements={this.props.rowElements} fixedRowElements={this.props.fixedRowElements} columns={this.props.columns} index={idx} Cell={this.props.Cell} isFixedRow={this.props.isFixedRow} className={((idx % 2) === 1) ? 'alt' : ''} visibleColumns={this.props.visibleColumns} />);
+    return groupRow.rows.map((r, idx) => <Row key={r.id} row={r} rowElements={this.props.rowElements} fixedRowElements={this.props.fixedRowElements} columns={this.props.columns} index={idx} Cell={this.props.Cell} isFixedColumnsRow={this.props.isFixedColumnsRow} className={((idx % 2) === 1) ? 'alt' : ''} visibleColumns={this.props.visibleColumns} />);
   }
 
   renderGroupRow(groupRow: IGroupRow) {

--- a/packages/rewire-grid/src/models/CellModel.ts
+++ b/packages/rewire-grid/src/models/CellModel.ts
@@ -168,7 +168,7 @@ export class CellModel implements ICell {
     this.value = undefined;
   }
 
-  hasChanges() {
+  hasChanges(): boolean {
     let changes: boolean;
     if (this.column.compare) {
       changes = this.column.compare(this.value, this.row.data[this.column.name]) !== 0;

--- a/packages/rewire-grid/src/models/GridTypes.ts
+++ b/packages/rewire-grid/src/models/GridTypes.ts
@@ -126,6 +126,7 @@ export interface IRow extends IDisposable {
   cellsByColumnPosition: ICell[];
   parentRow?           : IGroupRow;
   visible              : boolean;
+  isFixed              : boolean;
 
   hasChanges(): boolean;
   createCell(column: IColumn, value: any, type?: string): ICell;

--- a/packages/rewire-grid/src/models/RowModel.ts
+++ b/packages/rewire-grid/src/models/RowModel.ts
@@ -33,6 +33,7 @@ export class RowModel implements IRow, IDisposable {
   cls                  : string;
   visible              : boolean;
   options              : IRowOptions;
+  isFixed              : boolean;
   position             : number;
 
   dispose: () => void = EmptyFn;
@@ -50,6 +51,7 @@ export class RowModel implements IRow, IDisposable {
     this.visible  = true;
     this.position = position;
     this.options  = data && data.options;
+    this.isFixed  = fixed;
 
     if (data && data.id) {
       this.id = String(data.id);
@@ -107,7 +109,7 @@ export class RowModel implements IRow, IDisposable {
       }
 
       let cell = this.cells[column.name];
-      if (previousCell && cell && (previousValue === cell.value) && (previousCell.column.type === cell.column.type)) {
+      if (previousCell && cell && (previousValue === cell.value) && ((previousCell.row.isFixed && cell.row.isFixed) || (previousCell.column.type === cell.column.type))) {
         colSpan++;
         cell.colSpan = 0;
         continue;
@@ -126,7 +128,7 @@ export class RowModel implements IRow, IDisposable {
     }
   }
 
-  hasChanges() {
+  hasChanges(): boolean {
     for (const column of this.grid.columns) {
       let cell = this.cells[column.name];
       if (!cell) continue;

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.0-beta.73",
+  "version": "1.0.0-beta.77",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
     "react": "^16.4.2",
     "react-beautiful-dnd": "^9.0.2",
     "react-number-format": "^3.6.0",
-    "rewire-common": "^1.0.0-beta.73",
-    "rewire-core": "^1.0.0-beta.73"
+    "rewire-common": "^1.0.0-beta.77",
+    "rewire-core": "^1.0.0-beta.77"
   }
 }


### PR DESCRIPTION
…pixels causing display issues (cells were growing by a fraction of a pixel when in edit mode). The calculation for line-height based on font-size is now done and rounded solely in JS.

    - Merging cells of different types is now allowed again for header cells. Solves an unintended regression.
    - Fixed grid sort to sort more efficiently. (Removed unneccessary calls).