### PR TITLE
Rewire-ui: - Fix isEmail and isRegex validators to convert an undefin…

### DIFF
--- a/examples/src/Application.tsx
+++ b/examples/src/Application.tsx
@@ -634,7 +634,8 @@ class TestDialog extends Modal {
     email                : Form.email().label('Email').validators(isRequired).placeholder('enter a valid email'),
     password             : Form.password().label('Password').validators(and(isRequired, isSameAsOther('password_confirmation', 'passwords are not the same'))).placeholder('enter a password').updateOnChange(),
     password_confirmation: Form.password().label('Confirm Password').placeholder('confirm your password').updateOnChange(),
-    phone                : Form.phone().label('Phone Number').validators(isRequired).placeholder('your phone number'),
+    phone                : Form.phone().label('Phone Number (optional)').placeholder('your phone number'),
+    phoneCustom          : Form.phone({format: '#-##-###-####-#####'}).label('Phone Number Custom (optional)').placeholder('your phone number'),
     country              : Form.reference(countries).label('Country').placeholder('pick a country').startAdornment(() => <AccessibilityIcon />).validators(isRequired),
     time                 : Form.time().label('Time').placeholder('enter a time').validators(isRequired).validateOnUpdate(false),
     avatar               : Form.avatar({width: 1000, height: 1000, avatarDiameter: 150, cropRadius: 75}).label('Add Photo'),
@@ -674,6 +675,7 @@ const TestFormView = ({form}: {form: typeof testDialog.form}) => (
         <form.field.password.Editor />
         <form.field.password_confirmation.Editor />
         <form.field.phone.Editor />
+        <form.field.phoneCustom.Editor />
       </div>
       <div className='content'>
         <form.field.country.Editor className='span4' />

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.0-beta.88",
+  "version": "1.0.0-beta.89",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.0-beta.88",
+  "version": "1.0.0-beta.89",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.0-beta.88",
+  "version": "1.0.0-beta.89",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/worksight/rewire",
   "dependencies": {
     "is": "^3.2.1",
-    "rewire-core": "^1.0.0-beta.88"
+    "rewire-core": "^1.0.0-beta.89"
   }
 }

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.0-beta.88",
+  "version": "1.0.0-beta.89",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",
@@ -28,8 +28,8 @@
     "nanoid": "^1.2.3",
     "react": "^16.4.2",
     "resize-observer-polyfill": "^1.5.0",
-    "rewire-common": "^1.0.0-beta.88",
-    "rewire-core": "^1.0.0-beta.88",
-    "rewire-ui": "^1.0.0-beta.88"
+    "rewire-common": "^1.0.0-beta.89",
+    "rewire-core": "^1.0.0-beta.89",
+    "rewire-ui": "^1.0.0-beta.89"
   }
 }

--- a/packages/rewire-grid/src/components/Cell.tsx
+++ b/packages/rewire-grid/src/components/Cell.tsx
@@ -273,6 +273,14 @@ class Cell extends React.PureComponent<CellProps, {}> {
         return;
 
       case 'ArrowLeft':
+        if (this.cell.editing) {
+          evt.stopPropagation();
+          if (this.column.type === 'select' || this.column.type === 'checked') {
+            evt.preventDefault();
+          }
+          return;
+        }
+
         let prevCell: ICell | undefined;
         if (!evt.shiftKey || !this.grid.multiSelect) {
           prevCell = this.grid.previousCell(this.cell, true);
@@ -295,6 +303,14 @@ class Cell extends React.PureComponent<CellProps, {}> {
         return;
 
       case 'ArrowRight':
+        if (this.cell.editing) {
+          evt.stopPropagation();
+          if (this.column.type === 'select' || this.column.type === 'checked') {
+            evt.preventDefault();
+          }
+          return;
+        }
+
         let nextCell: ICell | undefined;
         if (!evt.shiftKey || !this.grid.multiSelect) {
           nextCell = this.grid.nextCell(this.cell, true);
@@ -489,8 +505,8 @@ class Cell extends React.PureComponent<CellProps, {}> {
         endOfTextOnFocus = true;
         selectOnFocus = false;
       }
-      let editorClasses   = undefined;
-      let cellType        = this.column.type;
+      let editorClasses = undefined;
+      let cellType      = this.column.type;
       let additionalProps = {};
       if (cellType === 'select') {
         editorClasses = {select: this.props.classes.selectEditorSelect, selectMenuItem: this.props.classes.editorPopupMenuItem};

--- a/packages/rewire-grid/src/components/GridKeyboardNavigation.tsx
+++ b/packages/rewire-grid/src/components/GridKeyboardNavigation.tsx
@@ -64,9 +64,9 @@ export default class GridKeyboardNavigation {
   }
 
   moveToNextControl(ctl: HTMLElement, direction: number) {
-    if (!this.canMove(ctl, direction)) {
-      return false;
-    }
+    // if (!this.canMove(ctl, direction)) {
+    //   return false;
+    // }
 
     let index = this.fields.indexOf(ctl);
     if (index < 0) {

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.0-beta.88",
+  "version": "1.0.0-beta.89",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
     "react": "^16.4.2",
     "react-beautiful-dnd": "^9.0.2",
     "react-number-format": "^3.6.0",
-    "rewire-common": "^1.0.0-beta.88",
-    "rewire-core": "^1.0.0-beta.88"
+    "rewire-common": "^1.0.0-beta.89",
+    "rewire-core": "^1.0.0-beta.89"
   }
 }

--- a/packages/rewire-ui/src/components/CheckField.tsx
+++ b/packages/rewire-ui/src/components/CheckField.tsx
@@ -20,6 +20,7 @@ const styles = (theme: Theme) => ({
   },
   checkboxContainerNoLabel: {
     display: 'flex',
+    flex: '1',
     alignItems: 'center',
   }
 });

--- a/packages/rewire-ui/src/models/Form.ts
+++ b/packages/rewire-ui/src/models/Form.ts
@@ -19,7 +19,8 @@ import editor, {
   TextAlignment,
   IField,
 } from '../components/editors';
-import {and, isEmail}    from './Validator';
+import {and, isEmail, isRegEx} from './Validator';
+import {defaultPhoneFormat, defaultPhoneMask} from '../components/PhoneField';
 import { createElement } from 'react';
 
 export type IFieldTypes = 'string' | 'static' | 'reference' | 'select' | 'number' | 'boolean' | 'date' | 'time' | 'avatar' | 'password' | 'email' | 'phone';
@@ -421,7 +422,11 @@ export default class Form {
   }
 
   static phone(editProps?: any): IFieldDefn {
-    return new BaseField('phone', editProps);
+    let field                 = new BaseField('phone', editProps);
+    let phoneLength           = ((editProps && editProps.format) || defaultPhoneFormat).replace(new RegExp('[^#]', 'g'), '').length;
+    let phoneRegEx            = new RegExp('^$|^[0-9]{' + phoneLength + '}$');
+    field.typeDefn.validators = isRegEx(phoneRegEx, 'phone number is not in a valid format');
+    return field;
   }
 
   static select(searcher: any, editProps?: any): IFieldDefn {

--- a/packages/rewire-ui/src/models/Validator.ts
+++ b/packages/rewire-ui/src/models/Validator.ts
@@ -21,7 +21,7 @@ export const isRegEx = (re: RegExp, text: string) => {
   return {
     linkedFieldNames: [],
     fn: (obj: ObjectType, fieldName: string, label: string | undefined, value: any) => {
-      if (!re.test(String(value).toLowerCase())) {
+      if (!re.test(String(value !== undefined ? value : '').toLowerCase())) {
         return text;
       }
       return undefined;
@@ -33,7 +33,7 @@ export const isEmail = {
   linkedFieldNames: [],
   fn: (obj: ObjectType, fieldName: string, label: string | undefined, value: any) => {
     const re = /(^$|^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$)/;
-    if (!re.test(String(value).toLowerCase())) {
+    if (!re.test(String(value !== undefined ? value : '').toLowerCase())) {
       return 'email is not in a valid format';
     }
     return undefined;


### PR DESCRIPTION
…ed value to an empty string, so that the regex tests work for undefined values when an empty value is a valid match.

    - Add a default validator to 'phone' fields, that makes sure that if the field isn't empty, it has the correct length. This length is determined by the 'format' of this phone number field.
    - Check Field inner container css changes for alignment fix in rewire-grid.

Rewire-grid: - Fix for grid cell left / right navigation while editing a cell. While editing, these keys will now only traverse the value being edited, and no longer prompt to go to the previous / next cell. Shift + Tab and Tab still accomplishes this while editing. The reason for this change is because when attempting to navigate a string value to edit, an accidental extra tap of the left or right arrow key while at the beginning or the end of the string is not an uncommon occurence, and should not produce such undesirable behaviour.