### PR TITLE
Rewire-ui: - new validators for greater than, greather than or equals…

### DIFF
--- a/examples/src/Application.tsx
+++ b/examples/src/Application.tsx
@@ -43,7 +43,7 @@ import {createGrid, createColumn, IError, ErrorSeverity}   from 'rewire-grid';
 import {Grid, ICell}         from 'rewire-grid';
 // import { ICell, collapseAll, expandAll } from 'rewire-grid/models/GridTypes';
 import {editor}       from 'rewire-ui';
-import {isRequired, isEmail, and, isSameAsOther} from 'rewire-ui';
+import {isRequired, isEmail, and, isSameAsOther, isGreaterThan, isGreaterThanOrEquals, isLessThan, isLessThanOrEquals} from 'rewire-ui';
 import './graphqltest';
 import doucheSuitDude from './images/doucheSuitDude.jpg';
 import { MuiThemeProvider, Theme, createMuiTheme } from '@material-ui/core/styles';
@@ -625,25 +625,27 @@ const Home = _Home;
 
 class TestDialog extends Modal {
   form = Form.create({
-    date                 : Form.date().label('Date').validators(isRequired),
-    dollars              : Form.number().label('Dollars').validators(isRequired).placeholder('Show me the money').disableErrors().startAdornment(() => <div style={{display: 'flex', alignItems: 'center'}}><AddIcon /><span>$</span></div>),
-    shouldI              : Form.select(searcher).label('Should I?').placeholder('choose!').startAdornment(() => <AccessibilityIcon />).validators(isRequired),
+    date                 : Form.date().label('Date').validators(isRequired).variant('outlined'),
+    dollars              : Form.number().label('Dollars').validators(isRequired).placeholder('Show me the money').disableErrors().startAdornment(() => <div style={{display: 'flex', alignItems: 'center'}}><AddIcon /><span>$</span></div>).variant('outlined'),
+    shouldI              : Form.select(searcher).label('Should I?').placeholder('choose!').startAdornment(() => <AccessibilityIcon />).validators(isRequired).variant('outlined'),
     isGreat              : Form.boolean().label('Is Great'),
     noLabel              : Form.boolean(),
     disabled             : Form.boolean().label('Disabled').disabled(() => true),
-    email                : Form.email().label('Email').validators(isRequired).placeholder('enter a valid email'),
-    password             : Form.password().label('Password').validators(and(isRequired, isSameAsOther('password_confirmation', 'passwords are not the same'))).placeholder('enter a password').updateOnChange(),
-    password_confirmation: Form.password().label('Confirm Password').placeholder('confirm your password').updateOnChange(),
-    phone                : Form.phone().label('Phone Number (optional)').placeholder('your phone number'),
-    phoneCustom          : Form.phone({format: '#-##-###-####-#####'}).label('Phone Number Custom (optional)').placeholder('your phone number'),
-    country              : Form.reference(countries).label('Country').placeholder('pick a country').startAdornment(() => <AccessibilityIcon />).validators(isRequired),
-    time                 : Form.time().label('Time').placeholder('enter a time').validators(isRequired).validateOnUpdate(false),
+    email                : Form.email().label('Email').validators(isRequired).placeholder('enter a valid email').variant('outlined'),
+    name                 : Form.string().label('Name').validators(isRequired).placeholder('enter your name').startAdornment(() => <AccessibilityIcon />).variant('outlined'),
+    password             : Form.password().label('Password').validators(and(isRequired, isSameAsOther('password_confirmation', 'passwords are not the same'))).placeholder('enter a password').updateOnChange().variant('outlined'),
+    password_confirmation: Form.password().label('Confirm Password').placeholder('confirm your password').variant('outlined').updateOnChange(),
+    phone                : Form.phone().label('Phone Number (optional)').placeholder('your phone number').variant('outlined'),
+    phoneCustom          : Form.phone({format: '#-##-###-####-#####'}).label('Phone Number Custom (optional)').placeholder('your phone number').variant('outlined'),
+    country              : Form.reference(countries).label('Country').placeholder('pick a country').startAdornment(() => <AccessibilityIcon />).validators(isRequired).variant('outlined'),
+    timeOut              : Form.time().label('Time Out').placeholder('enter a time').validators(and(isRequired, isLessThan('timeIn'))).variant('outlined'),
+    timeIn               : Form.time().label('Time In').placeholder('enter a time').validators(isRequired).variant('outlined'),
     avatar               : Form.avatar({width: 1000, height: 1000, avatarDiameter: 150, cropRadius: 75}).label('Add Photo'),
   }, {email: 'splace@worksight.net', isGreat: true, avatar: doucheSuitDude});
 
   constructor() {
     super('Test Form');
-    this.action('login', this.submit, {type: 'submit', disabled: () => this.form.hasErrors})
+    this.action('login', this.submit, {type: 'submit'})
         .action('cancel', {color: 'secondary', icon: 'cancel'});
   }
 
@@ -670,6 +672,7 @@ const TestFormView = ({form}: {form: typeof testDialog.form}) => (
         <form.field.noLabel.Editor className='span4' />
         <form.field.disabled.Editor className='span4' />
         <form.field.email.Editor className='span4' />
+        <form.field.name.Editor className='span4' />
       </div>
       <div className='content'>
         <form.field.password.Editor />
@@ -680,7 +683,8 @@ const TestFormView = ({form}: {form: typeof testDialog.form}) => (
       <div className='content'>
         <form.field.country.Editor className='span4' />
         <form.field.isGreat.Editor className='span4' />
-        <form.field.time.Editor className='span4' />
+        <form.field.timeOut.Editor className='span4' />
+        <form.field.timeIn.Editor className='span4' />
       </div>
       <div className='content'>
       <form.field.avatar.Editor />
@@ -690,7 +694,7 @@ const TestFormView = ({form}: {form: typeof testDialog.form}) => (
         <button style={{height: '30px'}}  value='Cancel' onClick={testDialog.actionFn('cancel')}>Cancel</button>
       </div>
     </FormView>
-  )} />;
+  )} />
 );
 
 

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.0-beta.89",
+  "version": "1.0.0-beta.90",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.0-beta.89",
+  "version": "1.0.0-beta.90",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.0-beta.89",
+  "version": "1.0.0-beta.90",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.0-beta.89",
+  "version": "1.0.0-beta.90",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-grid/src/components/Cell.tsx
+++ b/packages/rewire-grid/src/components/Cell.tsx
@@ -87,8 +87,11 @@ const styles = (theme: Theme) => ({
     display: 'flex',
     flex: '1',
   },
-  selectEditorSelect: {
+  editorSelectSelect: {
     padding: '0px 3px',
+  },
+  editorSelectInputRoot: {
+    alignItems: 'stretch',
   },
   editorPopupMenuItem: {
     fontSize: theme.fontSizes.body,
@@ -509,7 +512,7 @@ class Cell extends React.PureComponent<CellProps, {}> {
       let cellType      = this.column.type;
       let additionalProps = {};
       if (cellType === 'select') {
-        editorClasses = {select: this.props.classes.selectEditorSelect, selectMenuItem: this.props.classes.editorPopupMenuItem};
+        editorClasses = {inputRoot: this.props.classes.editorSelectInputRoot, select: this.props.classes.editorSelectSelect, selectMenuItem: this.props.classes.editorPopupMenuItem};
       } else if (cellType === 'checked') {
         editorClasses = {checkboxRoot: this.props.classes.editorCheckboxRoot};
       } else if (cellType === 'text' || cellType === 'date' || cellType === 'email' || cellType === 'password' || cellType === 'time' || cellType === 'number' || cellType === 'phone' || cellType === 'auto-complete') {

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.0-beta.89",
+  "version": "1.0.0-beta.90",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",
@@ -24,25 +24,25 @@
   },
   "homepage": "https://github.com/worksight/rewire",
   "dependencies": {
-    "@material-ui/core": "^3.2.0",
+    "@material-ui/core": "^3.4.0",
     "@material-ui/icons": "^3.0.1",
     "@types/classnames": "^2.2.6",
     "@types/color": "^3.0.0",
     "@types/deepmerge": "^2.2.0",
     "@types/material-ui": "^0.21.5",
-    "@types/node": "^10.10.2",
-    "@types/react": "^16.4.16",
+    "@types/node": "^10.12.2",
+    "@types/react": "^16.4.18",
     "classcat": "^3.2.3",
     "color": "^3.0.0",
     "deepmerge": "^2.2.1",
     "downshift": "^3.1.4",
     "fuse-box": "^3.4.0",
     "is": "^3.2.1",
-    "konva": "^2.4.0",
+    "konva": "^2.5.0",
     "prop-types": "^15.6.2",
     "react": "^16.4.2",
     "react-beautiful-dnd": "^9.0.2",
-    "react-number-format": "^3.6.0",
+    "react-number-format": "^4.0.3",
     "rewire-common": "^1.0.0-beta.89",
     "rewire-core": "^1.0.0-beta.89"
   }

--- a/packages/rewire-ui/src/components/AutoComplete.tsx
+++ b/packages/rewire-ui/src/components/AutoComplete.tsx
@@ -55,6 +55,13 @@ const styles = (theme: Theme) => ({
     height: 'auto',
     lineHeight: '1em',
   },
+  helperTextRoot: {
+    marginTop: '6px',
+  },
+  helperTextContained: {
+    marginLeft: '14px',
+    marginRight: '14px',
+  },
 });
 
 export type IAutoCompleteProps<T> = WithStyle<ReturnType<typeof styles>, ICustomProps<T> & React.InputHTMLAtrributes<any>>;
@@ -84,8 +91,8 @@ class AutoComplete<T> extends React.Component<IAutoCompleteProps<T>, any> {
   }
 
   renderInput = (classes: Record<IStyleClasses, string>, error: string | undefined, inputProps: any, InputProps: any, ref: (node: any) => any) => {
-    const { label, disabled, autoFocus, value, ...other }        = inputProps;
-    const { startAdornment, endAdornment, align, disableErrors } = InputProps;
+    const { label, disabled, autoFocus, value, ...other }                 = inputProps;
+    const { startAdornment, endAdornment, align, variant, disableErrors } = InputProps;
 
     return (
       <TextField
@@ -93,6 +100,7 @@ class AutoComplete<T> extends React.Component<IAutoCompleteProps<T>, any> {
         classes={{root: classes.formControlRoot}}
         value={value}
         label={label}
+        variant={variant}
         error={!disableErrors && !disabled && !!error}
         helperText={!disableErrors && <span>{(!disabled && error) || ''}</span>}
         inputRef={ref}
@@ -101,6 +109,7 @@ class AutoComplete<T> extends React.Component<IAutoCompleteProps<T>, any> {
         inputProps={{className: classes.nativeInput, style: {textAlign: align || 'left'}}}
         InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot}}}
         InputLabelProps={{shrink: true}}
+        FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
         {...other}
       />
     );
@@ -284,6 +293,7 @@ class AutoComplete<T> extends React.Component<IAutoCompleteProps<T>, any> {
         (nextProps.label !== this.props.label) ||
         (nextProps.placeholder !== this.props.placeholder) ||
         (nextProps.align !== this.props.align) ||
+        (nextProps.variant !== this.props.variant) ||
         (nextProps.disableErrors !== this.props.disableErrors) ||
         (nextProps.startAdornment !== this.props.startAdornment) ||
         (nextProps.endAdornment !== this.props.endAdornment)
@@ -291,7 +301,7 @@ class AutoComplete<T> extends React.Component<IAutoCompleteProps<T>, any> {
   }
 
   render() {
-    const { classes, theme, disabled, visible, error, label, placeholder, autoFocus, align, disableErrors } = this.props;
+    const { classes, theme, disabled, visible, error, label, placeholder, autoFocus, align, disableErrors, variant } = this.props;
     if (visible === false) {
       return null;
     }
@@ -326,7 +336,7 @@ class AutoComplete<T> extends React.Component<IAutoCompleteProps<T>, any> {
                   label: label,
                   placeholder: placeholder,
                 }),
-                {align: align, disableErrors: disableErrors, startAdornment: startAdornment, endAdornment: endAdornment},
+                {align: align, variant, disableErrors: disableErrors, startAdornment: startAdornment, endAdornment: endAdornment},
                 (node => {
                   this.suggestionsContainerNode = node;
                 }),

--- a/packages/rewire-ui/src/components/BlurInputHOC.tsx
+++ b/packages/rewire-ui/src/components/BlurInputHOC.tsx
@@ -31,6 +31,7 @@ export default class BlurInputHOC extends React.Component<IBlurProps, IBlurState
       (nextProps.label !== this.props.label) ||
       (nextProps.placeholder !== this.props.placeholder) ||
       (nextProps.align !== this.props.align) ||
+      (nextProps.variant !== this.props.variant) ||
       (nextProps.disableErrors !== this.props.disableErrors) ||
       (nextProps.startAdornment !== this.props.startAdornment) ||
       (nextProps.endAdornment !== this.props.endAdornment) ||

--- a/packages/rewire-ui/src/components/Dialog.tsx
+++ b/packages/rewire-ui/src/components/Dialog.tsx
@@ -58,7 +58,7 @@ export interface IDialogProps {
   transition?           : (props: any) => JSX.Element;
   transitionDuration?   : number;
   title?                : (dialog: Modal) => JSX.Element;
-  maxWidth?             : 'xs' | 'sm' | 'md' | false;
+  maxWidth?             : 'xs' | 'sm' | 'md' | 'lg' | false;
   ButtonRenderer?       : ActionRenderType;
 }
 

--- a/packages/rewire-ui/src/components/NumberField.tsx
+++ b/packages/rewire-ui/src/components/NumberField.tsx
@@ -5,7 +5,7 @@ import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import InputAdornment                from '@material-ui/core/InputAdornment';
 import {Theme}                       from '@material-ui/core/styles';
 import BlurInputHOC                  from './BlurInputHOC';
-import {TextAlignment}               from './editors';
+import {TextAlignment, TextVariant}  from './editors';
 import {withStyles, WithStyle}       from './styles';
 
 const styles = (theme: Theme) => ({
@@ -24,6 +24,13 @@ const styles = (theme: Theme) => ({
       color: 'inherit',
       opacity: 0.4,
     },
+  },
+  helperTextRoot: {
+    marginTop: '6px',
+  },
+  helperTextContained: {
+    marginLeft: '14px',
+    marginRight: '14px',
   },
 });
 
@@ -74,6 +81,7 @@ class NumberTextField extends React.Component<NumberFieldProps> {
       (nextProps.label !== this.props.label) ||
       (nextProps.placeholder !== this.props.placeholder) ||
       (nextProps.align !== this.props.align) ||
+      (nextProps.variant !== this.props.variant) ||
       (nextProps.disableErrors !== this.props.disableErrors) ||
       (nextProps.startAdornment !== this.props.startAdornment) ||
       (nextProps.endAdornment !== this.props.endAdornment)
@@ -124,9 +132,11 @@ class NumberTextField extends React.Component<NumberFieldProps> {
           inputProps={{className: this.props.classes.nativeInput, style: {textAlign: this.props.align || 'left'}}}
           InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: this.props.classes.inputRoot}}}
           InputLabelProps={{shrink: true}}
+          FormHelperTextProps={{classes: {root: this.props.classes.helperTextRoot, contained: this.props.classes.helperTextContained}}}
           fixedDecimalScale={this.props.fixed}
           customInput={TextField}
           placeholder={this.props.placeholder}
+          variant={this.props.variant}
           helperText={!this.props.disableErrors && <span>{(!this.props.disabled && this.props.error) || ''}</span>}
         />);
     }
@@ -155,9 +165,11 @@ class NumberTextField extends React.Component<NumberFieldProps> {
             inputProps={{className: props.classes.nativeInput, style: {textAlign: props.align || 'left'}}}
             InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: props.classes.inputRoot}}}
             InputLabelProps={{shrink: true}}
+            FormHelperTextProps={{classes: {root: props.classes.helperTextRoot, contained: props.classes.helperTextContained}}}
             fixedDecimalScale={props.fixed}
             customInput={TextField}
             placeholder={props.placeholder}
+            variant={props.variant}
             helperText={!props.disableErrors && <span>{(!props.disabled && props.error) || ''}</span>}
           />)
         }

--- a/packages/rewire-ui/src/components/PasswordField.tsx
+++ b/packages/rewire-ui/src/components/PasswordField.tsx
@@ -6,7 +6,7 @@ import {Theme}                       from '@material-ui/core/styles';
 import VisibilityIcon                from '@material-ui/icons/Visibility';
 import VisibilityOffIcon             from '@material-ui/icons/VisibilityOff';
 import BlurInputHOC                  from './BlurInputHOC';
-import {TextAlignment}               from './editors';
+import {TextAlignment, TextVariant}  from './editors';
 import {withStyles, WithStyle}       from './styles';
 
 const styles = (theme: Theme) => ({
@@ -38,6 +38,13 @@ const styles = (theme: Theme) => ({
       opacity: 0.4,
     },
   },
+  helperTextRoot: {
+    marginTop: '6px',
+  },
+  helperTextContained: {
+    marginLeft: '14px',
+    marginRight: '14px',
+  },
 });
 
 export interface IPasswordFieldProps {
@@ -49,6 +56,7 @@ export interface IPasswordFieldProps {
   label?           : string;
   placeholder?     : string;
   align?           : TextAlignment;
+  variant?         : TextVariant;
   selectOnFocus?   : boolean;
   endOfTextOnFocus?: boolean;
   updateOnChange?  : boolean;
@@ -83,6 +91,7 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
       (nextProps.label !== this.props.label) ||
       (nextProps.placeholder !== this.props.placeholder) ||
       (nextProps.align !== this.props.align) ||
+      (nextProps.variant !== this.props.variant) ||
       (nextProps.disableErrors !== this.props.disableErrors)
     );
   }
@@ -128,6 +137,7 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
           disabled={this.props.disabled}
           label={this.props.label}
           placeholder={this.props.placeholder}
+          variant={this.props.variant}
           error={!this.props.disableErrors && !this.props.disabled && !!this.props.error}
           helperText={!this.props.disableErrors && <span>{(!this.props.disabled && this.props.error) || ''}</span>}
           value={this.props.value}
@@ -139,6 +149,7 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
           inputProps={{autoFocus: this.props.autoFocus, className: this.props.classes.nativeInput, style: {textAlign: this.props.align || 'left'}}}
           InputProps={{endAdornment: adornment, classes: {root: this.props.classes.inputRoot, inputType: this.props.classes.inputType}}}
           InputLabelProps={{shrink: true}}
+          FormHelperTextProps={{classes: {root: this.props.classes.helperTextRoot, contained: this.props.classes.helperTextContained}}}
         />
       );
     }
@@ -153,6 +164,7 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
             disabled={props.disabled}
             label={props.label}
             placeholder={props.placeholder}
+            variant={props.variant}
             error={!props.disableErrors && !props.disabled && !!props.error}
             helperText={!props.disableErrors && <span>{(!props.disabled && props.error) || ''}</span>}
             value={props.value}
@@ -164,6 +176,7 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
             inputProps={{autoFocus: props.autoFocus, className: props.classes.nativeInput, style: {textAlign: props.align || 'left'}}}
             InputProps={{endAdornment: adornment, classes: {root: props.classes.inputRoot, inputType: props.classes.inputType}}}
             InputLabelProps={{shrink: true}}
+            FormHelperTextProps={{classes: {root: props.classes.helperTextRoot, contained: props.classes.helperTextContained}}}
           />
         }
       />

--- a/packages/rewire-ui/src/components/TextField.tsx
+++ b/packages/rewire-ui/src/components/TextField.tsx
@@ -3,7 +3,7 @@ import BlurInputHOC                  from './BlurInputHOC';
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import InputAdornment                from '@material-ui/core/InputAdornment';
 import {Theme}                       from '@material-ui/core/styles';
-import {TextAlignment}               from './editors';
+import {TextAlignment, TextVariant}  from './editors';
 import {withStyles, WithStyle}       from './styles';
 
 const styles = (theme: Theme) => ({
@@ -26,19 +26,25 @@ const styles = (theme: Theme) => ({
       opacity: 0.4,
     },
     '&[type=date]': {
-      padding: '4px 0px 4px 0px',
       '&::-webkit-clear-button': {
-        marginRight: '4px',
+        // marginRight: '4px',
       },
       '&::-webkit-inner-spin-button': {
-        // '-webkit-appearance': 'none',
-        marginRight: '1px',
+        '-webkit-appearance': 'none',
+        // marginRight: '1px',
       },
       '&::-webkit-calendar-picker-indicator': {
         marginTop: '2px',
         fontSize: '1.1em',
       },
     },
+  },
+  helperTextRoot: {
+    marginTop: '6px',
+  },
+  helperTextContained: {
+    marginLeft: '14px',
+    marginRight: '14px',
   },
 });
 
@@ -51,6 +57,7 @@ export interface ITextFieldProps {
   label?           : string;
   placeholder?     : string;
   align?           : TextAlignment;
+  variant?         : TextVariant;
   selectOnFocus?   : boolean;
   endOfTextOnFocus?: boolean;
   updateOnChange?  : boolean;
@@ -76,6 +83,7 @@ class TextFieldInternal extends React.Component<TextFieldPropsStyled> {
       (nextProps.label !== this.props.label) ||
       (nextProps.placeholder !== this.props.placeholder) ||
       (nextProps.align !== this.props.align) ||
+      (nextProps.variant !== this.props.variant) ||
       (nextProps.disableErrors !== this.props.disableErrors) ||
       (nextProps.startAdornment !== this.props.startAdornment) ||
       (nextProps.endAdornment !== this.props.endAdornment)
@@ -97,10 +105,10 @@ class TextFieldInternal extends React.Component<TextFieldPropsStyled> {
       return null;
     }
 
-    const {classes, type} = this.props;
-
-    const startAdornment = this.props.startAdornment ? <InputAdornment position='start' classes={{root: classes.inputAdornmentRoot}}>{this.props.startAdornment}</InputAdornment> : undefined;
-    const endAdornment   = this.props.endAdornment ? <InputAdornment position='end' classes={{root: classes.inputAdornmentRoot}}>{this.props.endAdornment}</InputAdornment> : undefined;
+    const {classes, type, variant} = this.props;
+    const startAdornment           = this.props.startAdornment ? <InputAdornment position='start' classes={{root: classes.inputAdornmentRoot}}>{this.props.startAdornment}</InputAdornment> : undefined;
+    const endAdornment             = this.props.endAdornment ? <InputAdornment position='end' classes={{root: classes.inputAdornmentRoot}}>{this.props.endAdornment}</InputAdornment> : undefined;
+    const inputTypeClassName       = type !== 'date' ? classes.inputType : undefined;
 
     if (this.props.updateOnChange) {
       return (
@@ -111,6 +119,7 @@ class TextFieldInternal extends React.Component<TextFieldPropsStyled> {
         disabled={this.props.disabled}
         label={this.props.label}
         placeholder={this.props.placeholder}
+        variant={variant}
         error={!this.props.disableErrors && !this.props.disabled && !!this.props.error}
         helperText={!this.props.disableErrors && <span>{(!this.props.disabled && this.props.error) || ''}</span>}
         value={this.props.value}
@@ -120,8 +129,9 @@ class TextFieldInternal extends React.Component<TextFieldPropsStyled> {
         onKeyDown={this.props.onKeyDown}
         onChange={(evt: React.ChangeEvent<HTMLInputElement>) => this.props.onValueChange(evt.target.value)}
         inputProps={{autoFocus: this.props.autoFocus, className: classes.nativeInput, style: {textAlign: this.props.align || 'left'}}}
-        InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, inputType: classes.inputType}}}
+        InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, inputType: inputTypeClassName}}}
         InputLabelProps={{shrink: true}}
+        FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
       />);
     }
 
@@ -135,6 +145,7 @@ class TextFieldInternal extends React.Component<TextFieldPropsStyled> {
           disabled={props.disabled}
           label={props.label}
           placeholder={props.placeholder}
+          variant={variant}
           error={!props.disableErrors && !props.disabled && !!props.error}
           helperText={!props.disableErrors && <span>{(!props.disabled && props.error) || ''}</span>}
           value={props.value}
@@ -144,8 +155,9 @@ class TextFieldInternal extends React.Component<TextFieldPropsStyled> {
           onKeyDown={props.onKeyDown}
           onChange={props.onChange}
           inputProps={{autoFocus: props.autoFocus, className: classes.nativeInput, style: {textAlign: props.align || 'left'}}}
-          InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, inputType: classes.inputType}}}
+          InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, inputType: inputTypeClassName}}}
           InputLabelProps={{shrink: true}}
+          FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
         />
       }
     />);

--- a/packages/rewire-ui/src/components/TimeInputField.tsx
+++ b/packages/rewire-ui/src/components/TimeInputField.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {Theme}                       from '@material-ui/core/styles';
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import InputAdornment                from '@material-ui/core/InputAdornment';
-import {TextAlignment}               from './editors';
+import {TextAlignment, TextVariant}  from './editors';
 import {withStyles, WithStyle}       from './styles';
 
 export class TimeValidator {
@@ -130,6 +130,13 @@ const styles = (theme: Theme) => ({
       opacity: 0.4,
     },
   },
+  helperTextRoot: {
+    marginTop: '6px',
+  },
+  helperTextContained: {
+    marginLeft: '14px',
+    marginRight: '14px',
+  },
 });
 
 export interface ITimeFieldProps {
@@ -140,6 +147,7 @@ export interface ITimeFieldProps {
   value?         : number;
   label?         : string;
   align?         : TextAlignment;
+  variant?       : TextVariant;
   placeholder?   : string;
   rounding?      : number;
   startAdornment?: JSX.Element;
@@ -178,6 +186,7 @@ class TimeInputField extends React.Component<TimeFieldProps, ITimeState> {
       (nextProps.label !== this.props.label) ||
       (nextProps.placeholder !== this.props.placeholder) ||
       (nextProps.align !== this.props.align) ||
+      (nextProps.variant !== this.props.variant) ||
       (nextProps.disableErrors !== this.props.disableErrors) ||
       (nextProps.startAdornment !== this.props.startAdornment) ||
       (nextProps.endAdornment !== this.props.endAdornment)
@@ -203,7 +212,7 @@ class TimeInputField extends React.Component<TimeFieldProps, ITimeState> {
   }
 
   render() {
-    const {classes, className, visible, disabled, error, label, placeholder, align, disableErrors, autoFocus} = this.props;
+    const {classes, className, visible, disabled, error, label, placeholder, align, disableErrors, autoFocus, variant} = this.props;
     if (visible === false) {
       return null;
     }
@@ -223,9 +232,11 @@ class TimeInputField extends React.Component<TimeFieldProps, ITimeState> {
         onChange={this.handleChange}
         onBlur={this.handleBlur}
         placeholder={placeholder}
+        variant={variant}
         inputProps={{autoFocus: autoFocus, className: classes.nativeInput, style: {textAlign: align || 'left'}}}
         InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot}}}
         InputLabelProps={{shrink: true}}
+        FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
       />);
   }
 }

--- a/packages/rewire-ui/src/components/editors.tsx
+++ b/packages/rewire-ui/src/components/editors.tsx
@@ -19,6 +19,7 @@ export interface IField {
   label?         : string;
   placeholder?   : string;
   align?         : TextAlignment;
+  variant?       : TextVariant;
   autoFocus?     : boolean;
   error?         : string;
   value?         : any;
@@ -33,6 +34,8 @@ export interface IField {
 export type EditorType = 'text' | 'static' | 'auto-complete' | 'select' | 'date' | 'time' | 'number' | 'checked' | 'switch' | 'password' | 'email' | 'phone' | 'avatar' | 'none';
 
 export type TextAlignment = 'left' | 'right' | 'center';
+
+export type TextVariant = 'standard' | 'outlined';
 
 export function compare<T>(x?: T, y?: T) {
   if (x && !y) {
@@ -87,6 +90,7 @@ export default function editor(type: EditorType, propsForEdit?: any): React.SFC<
             disableErrors={field.disableErrors}
             style={{width: '100%', minWidth: '120px', textAlign: field.align || 'left'}}
             align={field.align || 'left'}
+            variant={field.variant}
             selectedItem={field.value}
             onSelectItem={onValueChange}
             className={className}
@@ -113,6 +117,7 @@ export default function editor(type: EditorType, propsForEdit?: any): React.SFC<
             visible={field.visible}
             disableErrors={field.disableErrors}
             align={field.align || 'left'}
+            variant={field.variant}
             value={field.value && utc(field.value).toDateString()}
             type='date'
             className={className}
@@ -141,6 +146,7 @@ export default function editor(type: EditorType, propsForEdit?: any): React.SFC<
             visible={field.visible}
             disableErrors={field.disableErrors}
             align={field.align || 'left'}
+            variant={field.variant}
             className={className}
             classes={classes}
             startAdornment={field.startAdornment && field.startAdornment()}
@@ -165,6 +171,7 @@ export default function editor(type: EditorType, propsForEdit?: any): React.SFC<
             visible={field.visible}
             disableErrors={field.disableErrors}
             align={field.align || 'left'}
+            variant={field.variant}
             className={className}
             classes={classes}
             startAdornment={field.startAdornment && field.startAdornment()}
@@ -206,6 +213,7 @@ export default function editor(type: EditorType, propsForEdit?: any): React.SFC<
             visible={field.visible}
             disableErrors={field.disableErrors}
             align={field.align || 'left'}
+            variant={field.variant}
             className={className}
             classes={classes}
             hasAdornment={field.endAdornment}
@@ -230,6 +238,7 @@ export default function editor(type: EditorType, propsForEdit?: any): React.SFC<
             visible={field.visible}
             disableErrors={field.disableErrors}
             align={field.align || 'left'}
+            variant={field.variant}
             className={className}
             classes={classes}
             startAdornment={field.startAdornment && field.startAdornment()}
@@ -255,6 +264,7 @@ export default function editor(type: EditorType, propsForEdit?: any): React.SFC<
             visible={field.visible}
             disableErrors={field.disableErrors}
             align={field.align || 'left'}
+            variant={field.variant}
             className={className}
             classes={classes}
             startAdornment={field.startAdornment && field.startAdornment()}
@@ -311,6 +321,7 @@ export default function editor(type: EditorType, propsForEdit?: any): React.SFC<
             visible={field.visible}
             disableErrors={field.disableErrors}
             align={field.align || 'left'}
+            variant={field.variant}
             selectedItem={field.value}
             onSelectItem={onValueChange}
             className={className}
@@ -336,7 +347,7 @@ export default function editor(type: EditorType, propsForEdit?: any): React.SFC<
         )} />
       );
     case 'none':
-      return () => undefined;
+      return () => null;
   }
   throw new Error(`unknown editor for type:${type}`);
 }

--- a/packages/rewire-ui/src/models/Validator.ts
+++ b/packages/rewire-ui/src/models/Validator.ts
@@ -1,4 +1,33 @@
 import {defaultEquals} from 'rewire-core';
+import * as is from 'is';
+
+export function defaultGreaterThan(v1: any, v2: any) {
+  if (v1 === undefined || v1 === null || v2 === undefined || v2 === null) {
+    return true;
+  }
+
+  if (is.string(v1) && is.string(v2)) {
+    return v1.localeCompare(v2) > 0 ;
+  } else if ((is.number(v1) && is.number(v2)) || (is.date(v1) && is.date(v2))) {
+    return v1 > v2;
+  }
+
+  return true;
+}
+
+export function defaultLessThan(v1: any, v2: any) {
+  if (v1 === undefined || v1 === null || v2 === undefined || v2 === null) {
+    return true;
+  }
+
+  if (is.string(v1) && is.string(v2)) {
+    return v1.localeCompare(v2) < 0;
+  } else if ((is.number(v1) && is.number(v2)) || (is.date(v1) && is.date(v2))) {
+    return v1 < v2;
+  }
+
+  return true;
+}
 
 export function isNull(value?: any) {
   if ((value === undefined) || (value === null)) return true;
@@ -52,6 +81,66 @@ export const requiredWhenOtherIsNotNull = (fieldName: string) => {
   };
 };
 
+export const isGreaterThan = (fieldName: string, text?: string) => {
+  return {
+    linkedFieldNames: [fieldName],
+    fn: (obj: ObjectType, otherFieldName: string, otherLabel: string | undefined, otherValue: any): string | undefined => {
+      let value = obj[fieldName] && obj[fieldName].value;
+      if (!defaultGreaterThan(otherValue, value)) {
+        if (text) return text;
+        let label = obj[fieldName] && obj[fieldName].label;
+        return `${otherLabel || otherFieldName} must be greather than ${label || fieldName}`;
+      }
+      return undefined;
+    }
+  };
+};
+
+export const isGreaterThanOrEquals = (fieldName: string, text?: string) => {
+  return {
+    linkedFieldNames: [fieldName],
+    fn: (obj: ObjectType, otherFieldName: string, otherLabel: string | undefined, otherValue: any): string | undefined => {
+      let value = obj[fieldName] && obj[fieldName].value;
+      if (!defaultEquals(otherValue, value) && !defaultGreaterThan(otherValue, value)) {
+        if (text) return text;
+        let label = obj[fieldName] && obj[fieldName].label;
+        return `${otherLabel || otherFieldName} must be greather than or equals to ${label || fieldName}`;
+      }
+      return undefined;
+    }
+  };
+};
+
+export const isLessThan = (fieldName: string, text?: string) => {
+  return {
+    linkedFieldNames: [fieldName],
+    fn: (obj: ObjectType, otherFieldName: string, otherLabel: string | undefined, otherValue: any): string | undefined => {
+      let value = obj[fieldName] && obj[fieldName].value;
+      if (!defaultLessThan(otherValue, value)) {
+        if (text) return text;
+        let label = obj[fieldName] && obj[fieldName].label;
+        return `${otherLabel || otherFieldName} must be less than ${label || fieldName}`;
+      }
+      return undefined;
+    }
+  };
+};
+
+export const isLessThanOrEquals = (fieldName: string, text?: string) => {
+  return {
+    linkedFieldNames: [fieldName],
+    fn: (obj: ObjectType, otherFieldName: string, otherLabel: string | undefined, otherValue: any): string | undefined => {
+      let value = obj[fieldName] && obj[fieldName].value;
+      if (!defaultEquals(otherValue, value) && !defaultLessThan(otherValue, value)) {
+        if (text) return text;
+        let label = obj[fieldName] && obj[fieldName].label;
+        return `${otherLabel || otherFieldName} must be less than or equals to ${label || fieldName}`;
+      }
+      return undefined;
+    }
+  };
+};
+
 export const isSameAsOther = (fieldName: string, text?: string) => {
   return {
     linkedFieldNames: [fieldName],
@@ -60,7 +149,7 @@ export const isSameAsOther = (fieldName: string, text?: string) => {
       if (!defaultEquals(otherValue, value)) {
         if (text) return text;
         let label = obj[fieldName] && obj[fieldName].label;
-        return `${label || fieldName} must be the same as ${otherLabel || otherFieldName}`;
+        return `${otherLabel || otherFieldName} must be the same as ${label || fieldName}`;
       }
       return undefined;
     }
@@ -75,7 +164,7 @@ export const isDifferentFromOther = (fieldName: string, text?: string) => {
       if (defaultEquals(otherValue, value)) {
         if (text) return text;
         let label = obj[fieldName] && obj[fieldName].label;
-        return `${label || fieldName} must be different from ${otherLabel || otherFieldName}`;
+        return `${otherLabel || otherFieldName} must be different from ${label || fieldName}`;
       }
       return undefined;
     }

--- a/packages/rewire-ui/src/models/search.ts
+++ b/packages/rewire-ui/src/models/search.ts
@@ -1,5 +1,5 @@
-import {fetch, match}  from 'rewire-common';
-import {TextAlignment} from '../components/editors';
+import {fetch, match}               from 'rewire-common';
+import {TextAlignment, TextVariant} from '../components/editors';
 
 export interface ISearchOptions {
   parentId?: string;
@@ -76,6 +76,7 @@ export interface ICustomProps<T> {
   visible?              : boolean;
   error?                : string;
   align?                : TextAlignment;
+  variant?              : TextVariant;
   label?                : string;
   disableErrors?        : boolean;
   startAdornment?       : JSX.Element;

--- a/yarn.lock
+++ b/yarn.lock
@@ -622,6 +622,38 @@
     recompose "0.28.0 - 0.30.0"
     warning "^4.0.1"
 
+"@material-ui/core@^3.4.0":
+  version "3.4.0"
+  resolved "http://npm.ad.worksight.net:4873/@material-ui%2fcore/-/core-3.4.0.tgz#b33c00a3c20e856ed7a4700dd398f128647beb4a"
+  integrity sha512-iBBcCJzrQ+/UmjVKeX9ZqipOwWWcDvO/X5+pzReEnimtMj38mbS3j+ET4Hroi9l+HeTvJmxb2h+sfY54EvPRNQ==
+  dependencies:
+    "@babel/runtime" "7.1.2"
+    "@types/jss" "^9.5.6"
+    "@types/react-transition-group" "^2.0.8"
+    brcast "^3.0.1"
+    classnames "^2.2.5"
+    csstype "^2.5.2"
+    debounce "^1.1.0"
+    deepmerge "^2.0.1"
+    dom-helpers "^3.2.1"
+    hoist-non-react-statics "^3.0.0"
+    is-plain-object "^2.0.4"
+    jss "^9.3.3"
+    jss-camel-case "^6.0.0"
+    jss-default-unit "^8.0.2"
+    jss-global "^3.0.0"
+    jss-nested "^6.0.1"
+    jss-props-sort "^6.0.0"
+    jss-vendor-prefixer "^7.0.0"
+    keycode "^2.1.9"
+    normalize-scroll-left "^0.1.2"
+    popper.js "^1.14.1"
+    prop-types "^15.6.0"
+    react-event-listener "^0.6.2"
+    react-transition-group "^2.2.1"
+    recompose "0.28.0 - 0.30.0"
+    warning "^4.0.1"
+
 "@material-ui/icons@^3.0.1":
   version "3.0.1"
   resolved "http://npm.ad.worksight.net:4873/@material-ui%2ficons/-/icons-3.0.1.tgz#671fb3d04dcaf9351dbbd2bf82ae2ae72e3d93cd"
@@ -805,6 +837,11 @@
   resolved "http://npm.ad.worksight.net:4873/@types%2fnode/-/node-10.10.2.tgz#2a55b8d66f6945efc5da38489774e551248aa169"
   integrity sha512-yg1zoc4aUbsVyKg2eMpmNthOI+Edn2ntiLRxHjhGeFtTwg3CORdqkY0tBZh+TNPnTTtf4iyU5TVxbHVdEjrDTQ==
 
+"@types/node@^10.12.2":
+  version "10.12.2"
+  resolved "http://npm.ad.worksight.net:4873/@types%2fnode/-/node-10.12.2.tgz#d77f9faa027cadad9c912cd47f4f8b07b0fb0864"
+  integrity sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ==
+
 "@types/prop-types@*":
   version "15.5.5"
   resolved "http://npm.ad.worksight.net:4873/@types%2fprop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"
@@ -874,6 +911,14 @@
   version "16.4.16"
   resolved "http://npm.ad.worksight.net:4873/@types%2freact/-/react-16.4.16.tgz#99f91b1200ae8c2062030402006d3b3c3a177043"
   integrity sha512-lxyoipLWweAnLnSsV4Ho2NAZTKKmxeYgkTQ6PaDiPDU9JJBUY2zJVVGiK1smzYv8+ZgbqEmcm5xM74GCpunSEA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@^16.4.18":
+  version "16.4.18"
+  resolved "http://npm.ad.worksight.net:4873/@types%2freact/-/react-16.4.18.tgz#2e28a2e7f92d3fa7d6a65f2b73275c3e3138a13d"
+  integrity sha512-eFzJKEg6pdeaukVLVZ8Xb79CTl/ysX+ExmOfAAqcFlCCK5TgFDD9kWR0S18sglQ3EmM8U+80enjUqbfnUyqpdA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -3195,6 +3240,13 @@ hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
   integrity sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w==
 
+hoist-non-react-statics@^3.0.0:
+  version "3.1.0"
+  resolved "http://npm.ad.worksight.net:4873/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz#42414ccdfff019cd2168168be998c7b3bd5245c0"
+  integrity sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==
+  dependencies:
+    react-is "^16.3.2"
+
 hosted-git-info@^2.1.4:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz#23235b29ab230c576aab0d4f13fc046b0b038222"
@@ -3904,10 +3956,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "http://npm.ad.worksight.net:4873/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
-konva@^2.4.0:
-  version "2.4.1"
-  resolved "http://npm.ad.worksight.net:4873/konva/-/konva-2.4.1.tgz#b47f2d2af16f2bbf371952cd411362d931e11edc"
-  integrity sha512-uVmK6c3h+EMd97wYIR8d9w4gwbq1oGIsxwrODBpOd5wx74kdj6286cP8+jBBi4WFYIrQI24xx5YI2+gTnQaN8w==
+konva@^2.5.0:
+  version "2.5.0"
+  resolved "http://npm.ad.worksight.net:4873/konva/-/konva-2.5.0.tgz#0ed90c8aa2edae4114d41ab86f5ebe1f5030ff40"
+  integrity sha512-kElr8iDK9ahcVdGQwnmQJ9v7hZ48D0kEkG8xzW4zL3QhgXBAcKhznePYwf37HoJ48opqXwLXUzzAftHvxgjcCg==
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -5343,6 +5395,11 @@ react-event-listener@^0.6.2:
     prop-types "^15.6.0"
     warning "^4.0.1"
 
+react-is@^16.3.2, react-is@^16.5.2:
+  version "16.6.0"
+  resolved "http://npm.ad.worksight.net:4873/react-is/-/react-is-16.6.0.tgz#456645144581a6e99f6816ae2bd24ee94bdd0c01"
+  integrity sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g==
+
 react-lifecycles-compat@^3.0.2:
   version "3.0.4"
   resolved "http://npm.ad.worksight.net:4873/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -5357,10 +5414,10 @@ react-motion@^0.5.2:
     prop-types "^15.5.8"
     raf "^3.1.0"
 
-react-number-format@^3.6.0:
-  version "3.6.2"
-  resolved "http://npm.ad.worksight.net:4873/react-number-format/-/react-number-format-3.6.2.tgz#46fb692a88ed25808f0cb08fd12aeae4ae68295a"
-  integrity sha512-HsO11fH6WiugtJflrMQn3/Yhq2J4uEWLxrKCQbI1gSGAOwIhUsOGJJeP8Vci/U4A7xK5SjC95ngZU8//Nuz3Gg==
+react-number-format@^4.0.3:
+  version "4.0.3"
+  resolved "http://npm.ad.worksight.net:4873/react-number-format/-/react-number-format-4.0.3.tgz#23d6d6ee784b293f7abeca8b71fd16cdd4560c6c"
+  integrity sha512-p4N/HI3iID4fzguxUtwKy2X/wVQ89WZ+kIlT3/MT2v66Nr0RgCeWu3wJZBdaNCeCKrE646QW+rf/uLoA3hqorA==
   dependencies:
     prop-types "^15.6.0"
 


### PR DESCRIPTION
…, less than, and less than or equals.

    - The disableErrors flag for a form and individual fields now removes these fields from validation, in addition to not displaying their errors. Fields linked to these fields will still be validated (if they don't have the disableErrors flag set also).
    - Add variant prop to all input fields (to add outlined version).
    - Changes to the styling of various fields in order to properly support the new outlined versions of inputs.
    - Changes to helperText styling across fields.