### PR TITLE
Rewire-ui: - New 'multiselect' field added.

### DIFF
--- a/examples/src/Application.tsx
+++ b/examples/src/Application.tsx
@@ -385,6 +385,7 @@ function createTestGrid(nRows: number, nColumns: number) {
   cols.push(createColumn('timeColumn', 'Time', 'time', Math.trunc(Math.random() * 250 + 50) + 'px'));
   cols.push(createColumn('autoCompleteColumn', 'Auto Complete', {type: 'auto-complete', options: countries}, Math.trunc(Math.random() * 250 + 50) + 'px'));
   cols.push(createColumn('selectColumn', 'Select', {type: 'select', options: countries}, Math.trunc(Math.random() * 250 + 50) + 'px'));
+  cols.push(createColumn('multiselectColumn', 'MultiSelect', {type: 'multiselect', options: countries}, Math.trunc(Math.random() * 250 + 50) + 'px'));
   cols.push(createColumn('checkedColumn', 'Checked', 'checked', Math.trunc(Math.random() * 250 + 50) + 'px'));
 
   let complexColumn = createColumn('complexColumn', 'Complex', 'none', Math.trunc(Math.random() * 250 + 50) + 'px');
@@ -443,6 +444,7 @@ function createTestGrid(nRows: number, nColumns: number) {
       let colName = cols[column].name;
       if ((column <= 1 || column >= 4) && row === 1) v = undefined;
       else if ((colName === 'autoCompleteColumn') || (colName === 'selectColumn')) v = {id: '14', name: 'Austria'};
+      else if (colName === 'multiselectColumn') v = [{id: '14', name: 'Austria'}];
       else if (colName === 'checkedColumn') v = true;
       else if (colName === 'timeColumn') v = '7:30';
       else if (colName === 'dateColumn') v = '2018-11-11';
@@ -556,6 +558,7 @@ function createEmployeesGrid() {
   cols.push(createColumn('isActive', 'IsActive', 'checked'));
   cols.push(createColumn('timeColumn', 'Time', 'time'));
   cols.push(createColumn('selectColumn', 'Select', {type: 'select', options: countries}));
+  cols.push(createColumn('multiselectColumn', 'Multiselect', {type: 'multiselect', options: countries}));
   cols.push(createColumn('autoCompleteColumn', 'Auto Complete', {type: 'auto-complete', options: countries}));
 
   // add employee rows
@@ -566,6 +569,8 @@ function createEmployeesGrid() {
       let fieldName: string = cols[column].name;
       if (fieldName === 'name') {
         r[fieldName] = employees[row][fieldName]; // somehow make into a button that opens a dialog on click???
+      } else if (fieldName === 'multiselectColumn') {
+        r[fieldName] = [{id: '14', name: 'Austria'}];
       } else {
         r[fieldName] = employees[row][fieldName];
       }
@@ -625,23 +630,23 @@ const Home = _Home;
 
 class TestDialog extends Modal {
   form = Form.create({
-    date                 : Form.date().label('Date').validators(isRequired).variant('outlined'),
-    dollars              : Form.number().label('Dollars').validators(isRequired).placeholder('Show me the money').disableErrors().startAdornment(() => <div style={{display: 'flex', alignItems: 'center'}}><AddIcon /><span>$</span></div>).variant('outlined'),
-    shouldI              : Form.select(searcher).label('Should I?').placeholder('choose!').startAdornment(() => <AccessibilityIcon />).validators(isRequired).variant('outlined'),
+    date                 : Form.date().label('Date').validators(isRequired),
+    dollars              : Form.number().label('Dollars').validators(isRequired).placeholder('Show me the money').disableErrors().startAdornment(() => <div style={{display: 'flex', alignItems: 'center'}}><AddIcon /><span>$</span></div>),
+    shouldI              : Form.multiselect(searcher).label('Should I?').placeholder('choose!').startAdornment(() => <AccessibilityIcon />).validators(isRequired),
     isGreat              : Form.boolean().label('Is Great'),
     noLabel              : Form.boolean(),
     disabled             : Form.boolean().label('Disabled').disabled(() => true),
-    email                : Form.email().label('Email').validators(isRequired).placeholder('enter a valid email').variant('outlined'),
-    name                 : Form.string().label('Name').validators(isRequired).placeholder('enter your name').startAdornment(() => <AccessibilityIcon />).variant('outlined'),
-    password             : Form.password().label('Password').validators(and(isRequired, isSameAsOther('password_confirmation', 'passwords are not the same'))).placeholder('enter a password').updateOnChange().variant('outlined'),
-    password_confirmation: Form.password().label('Confirm Password').placeholder('confirm your password').variant('outlined').updateOnChange(),
-    phone                : Form.phone().label('Phone Number (optional)').placeholder('your phone number').variant('outlined'),
-    phoneCustom          : Form.phone({format: '#-##-###-####-#####'}).label('Phone Number Custom (optional)').placeholder('your phone number').variant('outlined'),
-    country              : Form.reference(countries).label('Country').placeholder('pick a country').startAdornment(() => <AccessibilityIcon />).validators(isRequired).variant('outlined'),
-    timeOut              : Form.time().label('Time Out').placeholder('enter a time').validators(and(isRequired, isLessThan('timeIn'))).variant('outlined'),
-    timeIn               : Form.time().label('Time In').placeholder('enter a time').validators(isRequired).variant('outlined'),
-    avatar               : Form.avatar({width: 1000, height: 1000, avatarDiameter: 150, cropRadius: 75}).label('Add Photo'),
-  }, {email: 'splace@worksight.net', isGreat: true, avatar: doucheSuitDude});
+    email                : Form.email().label('Email').validators(isRequired).placeholder('enter a valid email'),
+    name                 : Form.string().label('Name').validators(isRequired).placeholder('enter your name').startAdornment(() => <AccessibilityIcon />),
+    password             : Form.password().label('Password').validators(and(isRequired, isSameAsOther('password_confirmation', 'passwords are not the same'))).placeholder('enter a password').updateOnChange(),
+    password_confirmation: Form.password().label('Confirm Password').placeholder('confirm your password').updateOnChange(),
+    phone                : Form.phone().label('Phone Number (optional)').placeholder('your phone number'),
+    phoneCustom          : Form.phone({format: '#-##-###-####-#####'}).label('Phone Number Custom (optional)').placeholder('your phone number'),
+    country              : Form.reference(countries).label('Country').placeholder('pick a country').startAdornment(() => <AccessibilityIcon />).validators(isRequired),
+    timeOut              : Form.time().label('Time Out').placeholder('enter a time').validators(and(isRequired, isLessThan('timeIn'))),
+    timeIn               : Form.time().label('Time In').placeholder('enter a time').validators(isRequired),
+    avatar               : Form.avatar({width: 1000, height: 1000, avatarDiameter: 150, cropRadius: 75}).label('Add Photo (Optional)'),
+  }, {email: 'splace@worksight.net', isGreat: true}, {variant: 'outlined'});
 
   constructor() {
     super('Test Form');

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.0-beta.90",
+  "version": "1.0.0-beta.97",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.0-beta.90",
+  "version": "1.0.0-beta.97",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.0-beta.90",
+  "version": "1.0.0-beta.97",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/worksight/rewire",
   "dependencies": {
     "is": "^3.2.1",
-    "rewire-core": "^1.0.0-beta.89"
+    "rewire-core": "^1.0.0-beta.97"
   }
 }

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.0-beta.90",
+  "version": "1.0.0-beta.97",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",
@@ -28,8 +28,8 @@
     "nanoid": "^1.2.3",
     "react": "^16.4.2",
     "resize-observer-polyfill": "^1.5.0",
-    "rewire-common": "^1.0.0-beta.89",
-    "rewire-core": "^1.0.0-beta.89",
-    "rewire-ui": "^1.0.0-beta.89"
+    "rewire-common": "^1.0.0-beta.97",
+    "rewire-core": "^1.0.0-beta.97",
+    "rewire-ui": "^1.0.0-beta.97"
   }
 }

--- a/packages/rewire-grid/src/components/Row.tsx
+++ b/packages/rewire-grid/src/components/Row.tsx
@@ -4,7 +4,8 @@ import {
   IColumn,
   IGroupRow,
   getValue,
-  isGroupRow
+  isGroupRow,
+  cloneValue,
 }                              from '../models/GridTypes';
 import * as React              from 'react';
 import ResizeObserver          from 'resize-observer-polyfill';
@@ -67,12 +68,7 @@ const Row = withStyles(styles, class extends PureComponent<RowProps, {}> {
     super(props);
     let row = props.row;
     Object.keys(row.cells).forEach(columnName => {
-      let value = row.cells[columnName].value;
-      if (typeof value === 'object') {
-        row.data[columnName] = value.clone ? value.clone() : Object.assign({}, value);
-      } else {
-        row.data[columnName] = value;
-      }
+      row.data[columnName] = cloneValue(row.cells[columnName].value);
     });
   }
 

--- a/packages/rewire-grid/src/models/CellModel.ts
+++ b/packages/rewire-grid/src/models/CellModel.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {IGrid, IColumn, ICell, IRow, IError, TextAlignment} from './GridTypes';
+import {IGrid, IColumn, ICell, IRow, IError, TextAlignment, cloneValue} from './GridTypes';
 import { observable, defaultEquals, property, DataSignal } from 'rewire-core';
 
 let id = 0;
@@ -187,15 +187,10 @@ export class CellModel implements ICell {
     this.editing = value;
   }
 
-  clone(newRow: IRow) {
-    let newValue: any;
-    if (typeof this.value === 'object') {
-      newValue = this.value.clone ? this.value.clone() : Object.assign({}, this.value);
-    } else {
-      newValue = this.value;
-    }
-    let row     = newRow || this.row;
-    let newCell = new CellModel(row, this.column, newValue);
+  clone(newRow: IRow): any {
+    let newValue    = cloneValue(this.value);
+    let row         = newRow || this.row;
+    let newCell     = new CellModel(row, this.column, newValue);
     newCell.rowSpan = this.rowSpan;
     newCell.colSpan = this.colSpan;
     return newCell;

--- a/packages/rewire-grid/src/models/GridModel.ts
+++ b/packages/rewire-grid/src/models/GridModel.ts
@@ -12,10 +12,12 @@ import {
   IRowIteratorResult,
   IDisposable,
   findRowById,
+  cloneValue,
 }                              from './GridTypes';
 import createRow, {RowModel}   from './RowModel';
 import {ColumnModel}           from './ColumnModel';
 import {CellModel}             from './CellModel';
+import * as is                 from 'is';
 import {
   observable,
   computed,
@@ -328,13 +330,7 @@ class GridModel implements IGrid, IDisposable {
 
       this.dataRowsByPosition.forEach(row => {
         for (const column of this.columns) {
-          if (typeof row.cells[column.name].value === 'object' && row.data[column.name] !== undefined) {
-            Object.assign(row.cells[column.name].value, row.data[column.name]);
-          } else if (typeof row.data[column.name] === 'object') {
-            row.cells[column.name].value = row.data[column.name].clone ? row.data[column.name].clone() : Object.assign({}, row.data[column.name]);
-          } else {
-            row.cells[column.name].value = row.data[column.name];
-          }
+          row.cells[column.name].value = cloneValue(row.data[column.name]);
         }
       });
     });
@@ -460,12 +456,8 @@ class GridModel implements IGrid, IDisposable {
         return;
       }
 
-      let clipboardCell = clipboardCellsForColumn.shift();
-      if (typeof clipboardCell.value === 'object') {
-        selectedCell.value = clipboardCell.value.clone ? clipboardCell.value.clone() : Object.assign({}, clipboardCell.value);
-      } else {
-        selectedCell.value = clipboardCell.value;
-      }
+      let clipboardCell  = clipboardCellsForColumn.shift();
+      selectedCell.value = cloneValue(clipboardCell.value);
 
       if (clipboardCellsForColumn.length <= 0) {
         clipboardCellsByColumnPosition[selectedCell.columnPosition] = clipboardCellsByColumnPositionOriginal[selectedCell.columnPosition].slice();

--- a/packages/rewire-grid/src/models/GridTypes.ts
+++ b/packages/rewire-grid/src/models/GridTypes.ts
@@ -1,3 +1,4 @@
+import * as is             from 'is';
 import { EditorType }      from 'rewire-ui';
 import { SearchFn, MapFn } from 'rewire-ui';
 export { EditorType };
@@ -143,6 +144,7 @@ export type IColumnEditor =
   'text' | 'date' | 'time' | 'checked' | 'password' | 'mask' | 'none' |
   {type: 'auto-complete', options: {search: SearchFn<any>, map: MapFn<any>}} |
   {type: 'select', options: {search: SearchFn<any>, map: MapFn<any>}} |
+  {type: 'multiselect', options: {search: SearchFn<any>, map: MapFn<any>}} |
   {type: 'number', options?: {decimals?: number, thousandSeparator?: boolean, fixed?: boolean}} |
   {type: 'phone', options?: {format?: string, mask?: string}};
 
@@ -237,6 +239,16 @@ export function getValue(row: IRow | ObjectType, column: IColumn): string | unde
 
   if (column.map) value = column.map(value);
   return value;
+}
+
+export function cloneValue(value: any): any {
+  if (is.array(value)) {
+    return value.map((v: any) => this.cloneValue(v));
+  } else if (is.object(value)) {
+    return value.clone ? value.clone() : Object.assign({}, value);
+  } else {
+    return value;
+  }
 }
 
 export interface IRowIteratorResult {

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.0-beta.90",
+  "version": "1.0.0-beta.97",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
     "react": "^16.4.2",
     "react-beautiful-dnd": "^9.0.2",
     "react-number-format": "^4.0.3",
-    "rewire-common": "^1.0.0-beta.89",
-    "rewire-core": "^1.0.0-beta.89"
+    "rewire-common": "^1.0.0-beta.97",
+    "rewire-core": "^1.0.0-beta.97"
   }
 }

--- a/packages/rewire-ui/src/components/AvatarField.tsx
+++ b/packages/rewire-ui/src/components/AvatarField.tsx
@@ -156,9 +156,11 @@ const innerAvatarStyles = () => ({
     zIndex: -1,
   },
   label: {
-    fontSize: '1.2em',
+    fontSize: '1.1em',
     fontWeight: '600',
-    display: 'inline-block',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     cursor: 'pointer',
     width: '100%',
   },
@@ -226,7 +228,7 @@ const InnerAvatar = withStyles(innerAvatarStyles, class extends React.Component<
     const diameter             = (avatarDiameter || this.defaultInnerAvatarProps.avatarDiameter);
     const loaderLabel          = (label || this.defaultInnerAvatarProps.label);
     const diameterStr          = diameter + 'px';
-    const labelStyle           = {lineHeight: diameterStr};
+    const labelStyle           = {height: diameterStr};
     const loaderContainerStyle = {
       width: diameterStr,
       height: diameterStr,

--- a/packages/rewire-ui/src/components/Dialog.tsx
+++ b/packages/rewire-ui/src/components/Dialog.tsx
@@ -1,9 +1,11 @@
 import * as React            from 'react';
 import Modal, { ActionType } from '../models/Modal';
+import classNames            from 'classnames';
 import {Observe}             from 'rewire-core';
 import Typography            from '@material-ui/core/Typography';
 import Dialog                from '@material-ui/core/Dialog';
 import Button                from '@material-ui/core/Button';
+import Divider               from '@material-ui/core/Divider';
 import Icon                  from '@material-ui/core/Icon';
 import Grow                  from '@material-ui/core/Grow';
 import {Theme}               from '@material-ui/core/styles';
@@ -13,25 +15,45 @@ import {WithStyle, withStyles} from './styles';
 let styles = (theme: Theme) => ({
   root: {
     width: '100%',
+    overflowY: 'hidden',
+  },
+  scrollPaper: {
+    maxHeight: 'calc(100% - 72px)',
   },
   buttons: {
     alignSelf: 'flex-end',
     display: 'flex',
-    margin: 16,
+    flexShrink: '0',
+    margin: '15px',
     '& > button': {
-      marginLeft: 16
-    }
+      marginLeft: '15px',
+    },
   },
   heading: {
     display: 'flex',
+    flexShrink: '0',
     alignItems: 'center',
     flexDirection: 'column',
-    margin: 16,
+    margin: '15px 15px 0px 15px',
     '& > hr': {
-      marginTop: 16,
+      marginTop: '15px',
+      marginBottom: '0px',
       width: '85%',
       border: '1px solid #eee'
     },
+  },
+  childrenContainer: {
+    overflowY: 'auto',
+    margin: '1px 0px',
+    paddingBottom: '19px',
+    position: 'relative',
+  },
+  childrenContainerTitle: {
+    paddingTop: '15px',
+  },
+  divider: {
+    margin: '0px',
+    height: '1px',
   },
 });
 
@@ -55,6 +77,7 @@ export interface IDialogProps {
   disableEscapeKeyDown? : boolean;
   hideBackdrop?         : boolean;
   disableTransition?    : boolean;
+  hasDivider?           : boolean;
   transition?           : (props: any) => JSX.Element;
   transitionDuration?   : number;
   title?                : (dialog: Modal) => JSX.Element;
@@ -66,24 +89,29 @@ type DialogProps = WithStyle<ReturnType<typeof styles>, IDialogProps>;
 
 class DialogInternal extends React.Component<DialogProps> {
   render() {
-    const {classes, children, dialog, ButtonRenderer, fullScreen, maxWidth, title, disableEscapeKeyDown, hideBackdrop, transition, transitionDuration, disableTransition} = this.props;
+    const {classes, children, dialog, ButtonRenderer, fullScreen, maxWidth, title, disableEscapeKeyDown, hideBackdrop, transition, transitionDuration, disableTransition, hasDivider} = this.props;
     const escapeAction            = disableEscapeKeyDown ? undefined : () => dialog.close();
     const transitionToUse         = transition ? transition : Transition;
     const transitionDurationToUse = transitionDuration !== undefined ? transitionDuration : TRANSITION_TIMEOUT;
     const transitionAction        = disableTransition ? undefined : transitionToUse;
     const transitionTime          = disableTransition ? 0 : transitionDurationToUse;
+    const hasTitle                = dialog.title || title;
+    const hasActions              = dialog.actions && Object.keys(dialog.actions).length > 0;
 
     return (
       <Observe render={() => (
-        <Dialog classes={{paper: classes.root}} open={dialog.isOpen} fullWidth maxWidth={maxWidth} hideBackdrop={hideBackdrop} transitionDuration={transitionTime} TransitionComponent={transitionAction} fullScreen={fullScreen} disableEscapeKeyDown={disableEscapeKeyDown} onEscapeKeyDown={escapeAction}>
-          {(dialog.title || title) &&
+        <Dialog classes={{paper: classes.root, paperScrollPaper: classes.scrollPaper}} open={dialog.isOpen} fullWidth maxWidth={maxWidth} hideBackdrop={hideBackdrop} transitionDuration={transitionTime} TransitionComponent={transitionAction} fullScreen={fullScreen} disableEscapeKeyDown={disableEscapeKeyDown} onEscapeKeyDown={escapeAction}>
+          {hasTitle &&
             <div className={classes.heading}>
               <Typography variant='h6'>{(title && title(dialog)) || dialog.title}</Typography>
               <hr/>
             </div>}
-            {children}
-          {(dialog.actions && Object.keys(dialog.actions).length > 0) && <div className={classes.buttons}>{
-            Object.keys(dialog.actions).map(label => ((ButtonRenderer && <ButtonRenderer key={label} label={label} action={dialog.actions[label]} isDisabled={dialog.isDisabled} />) || <DefaultActionRenderer key={label} label={label} action={dialog.actions[label]} isDisabled={dialog.isDisabled} />))
+            <div className={classNames(classes.childrenContainer, hasTitle ? classes.childrenContainerTitle : '')}>
+              {children}
+            </div>
+          {hasActions && (hasDivider !== undefined ? hasDivider : true) && <Divider className={classes.divider} />}
+          {hasActions && <div className={classes.buttons}>{
+              Object.keys(dialog.actions).map(label => ((ButtonRenderer && <ButtonRenderer key={label} label={label} action={dialog.actions[label]} isDisabled={dialog.isDisabled} />) || <DefaultActionRenderer key={label} label={label} action={dialog.actions[label]} isDisabled={dialog.isDisabled} />))
           }</div>}
         </Dialog>
       )} />

--- a/packages/rewire-ui/src/components/editors.tsx
+++ b/packages/rewire-ui/src/components/editors.tsx
@@ -31,7 +31,7 @@ export interface IField {
   endAdornment?(): JSX.Element;
 }
 
-export type EditorType = 'text' | 'static' | 'auto-complete' | 'select' | 'date' | 'time' | 'number' | 'checked' | 'switch' | 'password' | 'email' | 'phone' | 'avatar' | 'none';
+export type EditorType = 'text' | 'static' | 'auto-complete' | 'select' | 'multiselect' | 'date' | 'time' | 'number' | 'checked' | 'switch' | 'password' | 'email' | 'phone' | 'avatar' | 'none';
 
 export type TextAlignment = 'left' | 'right' | 'center';
 
@@ -101,6 +101,33 @@ export default function editor(type: EditorType, propsForEdit?: any): React.SFC<
           />
         )} />
       );
+
+    case 'multiselect':
+    return ({field, className, classes, onValueChange}: TextEditorProps) => (
+      <Observe render={() => (
+        <Select
+          multiple={true}
+          label={field.label}
+          onValueChange={onValueChange}
+          placeholder={field.placeholder}
+          autoFocus={field.autoFocus}
+          error={field.error}
+          disabled={field.disabled && field.disabled(field)}
+          visible={field.visible}
+          disableErrors={field.disableErrors}
+          style={{width: '100%', minWidth: '120px', textAlign: field.align || 'left'}}
+          align={field.align || 'left'}
+          variant={field.variant}
+          selectedItem={field.value || []}
+          onSelectItem={onValueChange}
+          className={className}
+          classes={classes}
+          startAdornment={field.startAdornment && field.startAdornment()}
+          endAdornment={field.endAdornment && field.endAdornment()}
+          {...propsForEdit}
+        />
+      )} />
+    );
 
     case 'date':
       return ({field, className, classes, onValueChange, endOfTextOnFocus, selectOnFocus}: TextEditorProps) => (

--- a/packages/rewire-ui/src/models/Form.ts
+++ b/packages/rewire-ui/src/models/Form.ts
@@ -24,7 +24,7 @@ import {and, isEmail, isRegEx} from './Validator';
 import {defaultPhoneFormat} from '../components/PhoneField';
 import { createElement } from 'react';
 
-export type IFieldTypes = 'string' | 'static' | 'reference' | 'select' | 'number' | 'boolean' | 'date' | 'time' | 'avatar' | 'password' | 'email' | 'phone';
+export type IFieldTypes = 'string' | 'static' | 'reference' | 'select' | 'multiselect' | 'number' | 'boolean' | 'date' | 'time' | 'avatar' | 'password' | 'email' | 'phone';
 
 export interface IFieldDefn {
   label(text: string): IFieldDefn;
@@ -159,6 +159,7 @@ class BaseField implements IFieldDefn {
 export interface IFormOptions {
   defaultAdornmentsEnabled?: boolean;
   disableErrors?: boolean;
+  variant?: TextVariant;
   updateOnChange?: boolean;
   validateOnUpdate?: boolean;
 }
@@ -170,6 +171,7 @@ export default class Form {
   private _hasErrors      : () => boolean;
   defaultAdornmentsEnabled: boolean;
   disableErrors           : boolean;
+  variant                 : TextVariant;
   updateOnChange          : boolean;
   validateOnUpdate        : boolean;
   fields                  : IEditorField[];
@@ -181,6 +183,7 @@ export default class Form {
     this.validator                = new Validator();
     this.defaultAdornmentsEnabled = options && options.defaultAdornmentsEnabled !== undefined ? options.defaultAdornmentsEnabled : true;
     this.disableErrors            = options && options.disableErrors || false;
+    this.variant                  = options && options.variant || 'standard';
     // this.updateOnChange           = options && options.updateOnChange !== undefined ? options.updateOnChange : true;
     this.updateOnChange           = options && options.updateOnChange || false;
     this.validateOnUpdate         = options && options.validateOnUpdate !== undefined ? options.validateOnUpdate : true;
@@ -238,18 +241,19 @@ export default class Form {
   }
 
   private static editorDefaults: {[K in IFieldTypes]: EditorType} = {
-    'string'   : 'text',
-    'static'   : 'static',
-    'select'   : 'select',
-    'reference': 'auto-complete',
-    'boolean'  : 'checked',
-    'date'     : 'date',
-    'time'     : 'time',
-    'password' : 'password',
-    'email'    : 'email',
-    'phone'    : 'phone',
-    'number'   : 'number',
-    'avatar'   : 'avatar'
+    'string'     : 'text',
+    'static'     : 'static',
+    'select'     : 'select',
+    'multiselect': 'multiselect',
+    'reference'  : 'auto-complete',
+    'boolean'    : 'checked',
+    'date'       : 'date',
+    'time'       : 'time',
+    'password'   : 'password',
+    'email'      : 'email',
+    'phone'      : 'phone',
+    'number'     : 'number',
+    'avatar'     : 'avatar',
   };
 
   private createEditor(editorType: EditorType | undefined, field: IEditorField, editProps?: any): React.SFC<any> {
@@ -278,10 +282,10 @@ export default class Form {
       type: fieldDefn.typeDefn.type,
       placeholder: fieldDefn.typeDefn.placeholder,
       align: fieldDefn.typeDefn.align,
-      variant: fieldDefn.typeDefn.variant,
       label: fieldDefn.typeDefn.label,
       disabled: fieldDefn.typeDefn.disabled,
       disableErrors: fieldDefn.typeDefn.disableErrors !== undefined ? fieldDefn.typeDefn.disableErrors : this.disableErrors,
+      variant: fieldDefn.typeDefn.variant || this.variant,
       updateOnChange: fieldDefn.typeDefn.updateOnChange !== undefined ? fieldDefn.typeDefn.updateOnChange : this.updateOnChange,
       validateOnUpdate: fieldDefn.typeDefn.validateOnUpdate !== undefined ? fieldDefn.typeDefn.validateOnUpdate : this.validateOnUpdate,
       visible: true,
@@ -342,6 +346,7 @@ export default class Form {
   public clear() {
     this.fields.forEach(field => {
       field.value = undefined;
+      field.error = undefined;
     });
   }
 
@@ -443,6 +448,11 @@ export default class Form {
   static select(searcher: any, editProps?: any): IFieldDefn {
     let eProps = Object.assign({}, searcher, editProps);
     return new BaseField('select', eProps);
+  }
+
+  static multiselect(searcher: any, editProps?: any): IFieldDefn {
+    let eProps = Object.assign({}, searcher, editProps);
+    return new BaseField('multiselect', eProps);
   }
 
   static reference(searcher: any, editProps?: any): IFieldDefn {

--- a/packages/rewire-ui/src/models/Validator.ts
+++ b/packages/rewire-ui/src/models/Validator.ts
@@ -31,7 +31,6 @@ export function defaultLessThan(v1: any, v2: any) {
 
 export function isNull(value?: any) {
   if ((value === undefined) || (value === null)) return true;
-  if (value === null) return true;
   if (typeof(value) === 'string') return !value;
   return ((value.id !== undefined) && !value.id);
 }
@@ -42,7 +41,7 @@ export type IValidateFnData = {linkedFieldNames: string[], fn: IValidateFn};
 export const isRequired = {
   linkedFieldNames: [],
   fn: (obj: ObjectType, fieldName: string, label: string | undefined, value: any) => {
-    return (isNull(value)) ? `${label || 'field'} is required` : undefined;
+    return (isNull(value) || (is.array(value) && value.length <= 0)) ? `${label || 'field'} is required` : undefined;
   }
 };
 


### PR DESCRIPTION
    - isRequired validator now returns an error if the value is an empty array. (used for multiselect)
     - Form clear() now clears form errors as well.
    - added 'variant' as a form level setting as well, as you generally would never want to mix variants within a single form, as it would look inconsistent.
    - Select Field arrow positioning changes for selects of variant 'outline'
    - Avatar field label style changes to properly accomodate labels spanning across multiple lines.
    - Dialog changed to have it's scroll bar only scroll the dialog contents, while the title and buttons always remain visible, if large enough.
    - Dialog now has a divider between the contents and the action buttons, if they exist. This can be turned on / off with the flag 'hasDivider'. Enabled by default.
    - Select Field fix for display without a label. Now will correctly show errors / variant if available.

Rewire-grid: -  Fix for cell value tooltips to properly use the column mapping.
    - Add 'multiselect' column type.
    - Many code modifications made in order to support arrays as cell values. Needed for multiselect.