### PR TITLE
Rewire-Ui: - Made the DefaultActionRenderer (button) defined in Dialo…

### DIFF
--- a/examples/src/Application.tsx
+++ b/examples/src/Application.tsx
@@ -510,9 +510,9 @@ function createTestGrid(nRows: number, nColumns: number) {
   cols.push(createColumn('checkedColumn', 'Checked', 'checked', Math.trunc(Math.random() * 250 + 50) + 'px'));
 
   cols[15].validator = gridIsRequired;
-  cols[17].onValueChange = (row: IRow, value: any) => row.cells['differenceColumn'].setValue((row.cells['timeInColumn'].value || 0) - (value || 0));
+  cols[17].onValueChange = (cell: ICell, value: any) => cell.row.cells['differenceColumn'].setValue((cell.row.cells['timeInColumn'].value || 0) - (value || 0));
   cols[18].validator = gridIsGreaterThan('timeOutColumn');
-  cols[18].onValueChange = (row: IRow, value: any) => row.cells['differenceColumn'].setValue((value || 0) - (row.cells['timeOutColumn'].value || 0));
+  cols[18].onValueChange = (cell: ICell, value: any) => cell.row.cells['differenceColumn'].setValue((value || 0) - (cell.row.cells['timeOutColumn'].value || 0));
   cols[19].validator = gridIsDifferenceOfOthers(['timeInColumn', 'timeOutColumn']);
   cols[20].validator = gridIsSumOfOthers(['timeInColumn', 'timeOutColumn']);
 
@@ -793,7 +793,7 @@ const _Home = (props: any) => <Observe render={() => (
     <div>
       <div>
         {/* <span>{testDate.toDateString()}</span> */}
-        <Button color='primary' variant='contained' style={{marginRight: '15px'}} onClick={() => {loginDialog.form.clear(); loginDialog.open(); }}>Load Dialog Test</Button>
+        <Button color='primary' variant='contained' style={{marginRight: '15px'}} onClick={() => {loginDialog.open(); }}>Load Dialog Test</Button>
         <Button color='primary' variant='contained' onClick={() => gridHotkeysDialogModel.open()}>Load Grid Hotkeys List</Button>
         <DialogLoginForm />
         <GridHotkeysDialog />
@@ -817,8 +817,7 @@ const _Home = (props: any) => <Observe render={() => (
             <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => grid.dataRowsByPosition.forEach(row => row.clear(['numberColumn', 'dateColumn']))}>Clear Number And Date</Button>
             <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => {
               grid.dataRowsByPosition.forEach(row => {
-                let id = row.cells['complexColumn'].value ? row.cells['complexColumn'].value.id : nanoid(10);
-                row.cells['complexColumn'].setValue(new ComplexCellData(id, 'Smithers', 57));
+                row.cells['complexColumn'].setValue(new ComplexCellData('smithers027', 'Smithers', 57));
               });
             }}>
               Change Complex Cell Value
@@ -875,8 +874,8 @@ class TestDialog extends Modal {
 
   constructor() {
     super('Test Form');
-    this.action('login', this.submit, {type: 'submit'})
-        .action('cancel', {color: 'secondary', icon: 'cancel'});
+    this.action('login', this.submit, {type: 'submit', disabled: () => !this.form.hasChanges})
+        .action('cancel', {color: 'secondary', icon: 'cancel'})
   }
 
   submit = async () => {

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.0-beta.131",
+  "version": "1.0.0-beta.141",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.0-beta.131",
+  "version": "1.0.0-beta.141",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.0-beta.131",
+  "version": "1.0.0-beta.141",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/worksight/rewire",
   "dependencies": {
     "is": "^3.2.1",
-    "rewire-core": "^1.0.0-beta.131"
+    "rewire-core": "^1.0.0-beta.141"
   }
 }

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.0-beta.131",
+  "version": "1.0.0-beta.141",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",
@@ -27,11 +27,12 @@
     "deepmerge": "^3.1.0",
     "fast-deep-equal": "^2.0.1",
     "is": "^3.2.1",
+    "mixin-deep": "^2.0.0",
     "nanoid": "^1.2.3",
     "react": "^16.4.2",
     "resize-observer-polyfill": "^1.5.0",
-    "rewire-common": "^1.0.0-beta.131",
-    "rewire-core": "^1.0.0-beta.131",
-    "rewire-ui": "^1.0.0-beta.131"
+    "rewire-common": "^1.0.0-beta.141",
+    "rewire-core": "^1.0.0-beta.141",
+    "rewire-ui": "^1.0.0-beta.141"
   }
 }

--- a/packages/rewire-grid/src/models/ColumnModel.ts
+++ b/packages/rewire-grid/src/models/ColumnModel.ts
@@ -1,4 +1,4 @@
-import { IColumn, IRow, EditorType, IColumnEditor, SortDirection, IGrid, TextAlignment, VerticalAlignment, IError } from './GridTypes';
+import { IColumn, ICell, EditorType, IColumnEditor, SortDirection, IGrid, TextAlignment, VerticalAlignment, IError } from './GridTypes';
 import {IValidateFnData} from './Validator';
 import {editor, compare, defaultPhoneFormat, defaultPhoneMask} from 'rewire-ui';
 import {freeze} from 'rewire-core';
@@ -33,7 +33,7 @@ export class ColumnModel implements IColumn {
   editor?       : React.SFC<any>;
   validator?    : IValidateFnData;
 
-  onValueChange?(row: IRow, v: any): void;
+  onValueChange?(cell: ICell, v: any): void;
   map?(value: any): string;
   predicate?(value: any, filter: {value: any}): boolean;
   compare?(x: any, y: any): number;

--- a/packages/rewire-grid/src/models/GridTypes.ts
+++ b/packages/rewire-grid/src/models/GridTypes.ts
@@ -197,35 +197,35 @@ export type IColumnEditor =
   {type: 'phone', options?: {format?: string, mask?: string}};
 
 export interface ICellProperties {
-  id            : number;
-  grid          : IGrid;
-  tooltip?      : string;
-  cls?          : any;
-  editable      : boolean;
-  align?        : TextAlignment;
-  renderer?     : React.SFC<any>;
-  colSpan?      : number;
-  rowSpan?      : number;
+  id       : number;
+  grid     : IGrid;
+  tooltip? : string;
+  cls?     : any;
+  editable : boolean;
+  align?   : TextAlignment;
+  renderer?: React.SFC<any>;
+  colSpan? : number;
+  rowSpan? : number;
 
-  onValueChange?(row: IRow, v: any): void;
+  onValueChange?(cell: ICell, v: any): void;
 }
 
 export interface IColumn extends ICellProperties {
-  name      : string;
-  type      : EditorType;
-  title?    : string;
-  width?    : string;
-  fixed     : boolean;
-  visible   : boolean;
+  name          : string;
+  type          : EditorType;
+  title?        : string;
+  width?        : string;
+  fixed         : boolean;
+  visible       : boolean;
   verticalAlign?: VerticalAlignment;
   enabled?      : boolean;
   readOnly?     : boolean;
-  position  : number;
-  sort?     : SortDirection;
-  canSort?  : boolean;
-  options?  : any;
-  editor?   : React.SFC<any>;
-  validator?: IValidateFnData;
+  position      : number;
+  sort?         : SortDirection;
+  canSort?      : boolean;
+  options?      : any;
+  editor?       : React.SFC<any>;
+  validator?    : IValidateFnData;
 
   map?(value: any): string;
   predicate?(value: any, filter: {value: any}): boolean;

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.0-beta.131",
+  "version": "1.0.0-beta.141",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
     "react": "^16.4.2",
     "react-beautiful-dnd": "^9.0.2",
     "react-number-format": "^4.0.3",
-    "rewire-common": "^1.0.0-beta.131",
-    "rewire-core": "^1.0.0-beta.131"
+    "rewire-common": "^1.0.0-beta.141",
+    "rewire-core": "^1.0.0-beta.141"
   }
 }

--- a/packages/rewire-ui/src/components/Dialog.tsx
+++ b/packages/rewire-ui/src/components/Dialog.tsx
@@ -4,7 +4,7 @@ import classNames            from 'classnames';
 import {Observe}             from 'rewire-core';
 import Typography            from '@material-ui/core/Typography';
 import Dialog                from '@material-ui/core/Dialog';
-import Button                from '@material-ui/core/Button';
+import Button, {ButtonProps} from '@material-ui/core/Button';
 import Divider               from '@material-ui/core/Divider';
 import Icon                  from '@material-ui/core/Icon';
 import Grow                  from '@material-ui/core/Grow';
@@ -57,13 +57,18 @@ let styles = (theme: Theme) => ({
   },
 });
 
-export type ActionRenderType = (props: {label: string, action: ActionType, isDisabled: boolean}) => JSX.Element;
-export const DefaultActionRenderer: ActionRenderType = ({label, action, isDisabled}) => (
+export interface IDefaultActionRendererStyles {
+  button?: string;
+  icon?: string;
+  label?: string;
+}
+export type ActionRenderType = (props: {label: string, action: ActionType, isDisabled: boolean, variant?: ButtonProps['variant'], classes?: IDefaultActionRendererStyles}) => JSX.Element;
+export const DefaultActionRenderer: ActionRenderType = ({label, action, isDisabled, variant, classes}) => (
   <Observe render={() => (
-    <Button type={action.type} color={action.type ? 'primary' : action.color} disabled={isDisabled || action.disabled()} onClick={action.action}>
-    {action.icon && <Icon style={{marginRight: '8px'}}>{action.icon}</Icon>}
-    {label}
-  </Button>
+    <Button className={classes && classes.button} type={action.type} color={action.type ? 'primary' : action.color} variant={variant} disabled={isDisabled || action.disabled()} onClick={action.action}>
+      {action.icon && <Icon className={classes && classes.icon} style={{marginRight: '8px'}}>{action.icon}</Icon>}
+      <span className={classes && classes.label}>{label}</span>
+    </Button>
   )} />
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4429,6 +4429,11 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mixin-deep@^2.0.0:
+  version "2.0.0"
+  resolved "http://npm.ad.worksight.net:4873/mixin-deep/-/mixin-deep-2.0.0.tgz#9dfd525156720ec6cbee14fcb4b968253ba358ee"
+  integrity sha512-2tAhDtV+OCFCeknyf2cJD5rD+xfvM2ax/RZ3iI1G67Eh6x5UxKJlGDVpmCX27y7WvuXpAkMHQs9ooaxIHIit+A==
+
 mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"


### PR DESCRIPTION
…g support inner styling customization via a passed in classes parameter.

    - Form set value now properly initializes all field errors to undefined.
    - New Form methods reset and revert. Reset resets the form value to the value it was initialized with during creation, and revert sets the form value to its current value (and thus sets all the field values to what they were the last time the form had its value set).

Rewire-Grid: - Changed the Column and Cell model onValueChange function property to accept the ICell and value as parameters, instead of IRow and value. It didn't make sense to not know which cell was changed, and you can get the row off of the cell anyway.
    - setting cell values from one object to another will deeply assign the new value into the old. This is done for observable purposes, as overwriting an existing object with one that had the same id (yet could have different other properties) was not triggering the observable to save the new value.