### PR TITLE
Rewire-Core: - defaultEquals now equates the empty string to undefine…

### DIFF
--- a/examples/src/Application.tsx
+++ b/examples/src/Application.tsx
@@ -1,66 +1,96 @@
-import * as React            from 'react';
-import * as ReactDOM         from 'react-dom';
-import {AutoComplete}        from 'rewire-ui';
-import {
-  arraySearch,
-  documentSearch
-}                            from 'rewire-ui';
-import {Select}              from 'rewire-ui';
-import { observable, watch, root } from 'rewire-core';
-import {Observe}             from 'rewire-core';
-import {fetch}               from 'rewire-common';
-// import TextField          from 'material-ui/TextField';
-import {TextField}           from 'rewire-ui';
-import {NumberField}         from 'rewire-ui';
-import Button                from '@material-ui/core/Button';
-import Typography            from '@material-ui/core/Typography';
-import { withStyles }        from '@material-ui/core/styles';
-import AddIcon               from '@material-ui/icons/Add';
-import AccessibilityIcon     from '@material-ui/icons/Accessibility';
-import {Sortable, SortableList, IItem} from 'rewire-ui';
+import * as React    from 'react';
+import * as ReactDOM from 'react-dom';
+import * as nanoid   from 'nanoid';
+import * as is       from 'is';
 import {
   BrowserRouter as Router,
   Route,
   Link,
   NavLink,
 } from 'react-router-dom';
-import * as nanoid from 'nanoid';
-// import {TimeInputField} from 'rewire-ui';
-import {utc}            from 'rewire-common';
-// import Grid           from './components/Grid';
-import Paper          from '@material-ui/core/Paper';
-import Dialog         from '@material-ui/core/Dialog';
-import ListItem       from '@material-ui/core/ListItem';
-import {delay}        from 'rewire-common';
-import {Loader}       from 'rewire-ui';
-import * as is        from 'is';
-import {Form, IFormOptions}         from 'rewire-ui';
-import { IObject }    from 'rewire-common';
-import {Modal}        from 'rewire-ui';
-import {Dialog as DialogView}   from 'rewire-ui';
-import {FormView}     from 'rewire-ui';
-// import column         from './models/Grid';
-import {createGrid, createColumn, IError, ErrorSeverity}   from 'rewire-grid';
-import {Grid, IGridOptions, ICell, IRow, isLessThan as gridIsLessThan, isGreaterThan as gridIsGreaterThan, isRequired as gridIsRequired, isSumOfOthers as gridIsSumOfOthers, isDifferenceOfOthers as gridIsDifferenceOfOthers}   from 'rewire-grid';
-// import { ICell, collapseAll, expandAll } from 'rewire-grid/models/GridTypes';
-import {editor}       from 'rewire-ui';
-import {isRequired, isEmail, and, isSameAsOther, isGreaterThan, isGreaterThanOrEquals, isLessThan, isLessThanOrEquals, isDifferenceOfOthers, isSumOfOthers, requiredWhenOtherIsNotNull, requiredWhenOtherIsValue} from 'rewire-ui';
+import {
+  fetch,
+  utc,
+  delay,
+  IObject,
+} from 'rewire-common';
+import {
+  Observe,
+  observable,
+  watch,
+  root} from 'rewire-core';
+import {
+  Sortable,
+  SortableList,
+  IItem,
+  arraySearch,
+  documentSearch,
+  AutoComplete,
+  Select,
+  TextField,
+  NumberField,
+  Loader,
+  Form,
+  FormView,
+  IFormOptions,
+  Modal,
+  Dialog as DialogView,
+  editor,
+  isRequired,
+  and,
+  isSameAsOther,
+  isDifferentFromOther,
+  isDifferenceOfOthers,
+  isSumOfOthers,
+  isLessThan,
+  requiredWhenOtherIsNotNull,
+  requiredWhenOtherIsValue,
+} from 'rewire-ui';
+import {
+  createGrid,
+  createColumn,
+  IError,
+  ErrorSeverity,
+  Grid,
+  IGridOptions,
+  ICell,
+  IRow,
+  isLessThan as gridIsLessThan,
+  isGreaterThan as gridIsGreaterThan,
+  isRequired as gridIsRequired,
+  isSumOfOthers as gridIsSumOfOthers,
+  isDifferenceOfOthers as gridIsDifferenceOfOthers,
+} from 'rewire-grid';
+
+import Paper             from '@material-ui/core/Paper';
+import Dialog            from '@material-ui/core/Dialog';
+import ListItem          from '@material-ui/core/ListItem';
+import Button            from '@material-ui/core/Button';
+import Typography        from '@material-ui/core/Typography';
+import {withStyles}      from '@material-ui/core/styles';
+import AddIcon           from '@material-ui/icons/Add';
+import AccessibilityIcon from '@material-ui/icons/Accessibility';
+import {
+  MuiThemeProvider,
+  Theme,
+  createMuiTheme
+} from '@material-ui/core/styles';
+
 import './graphqltest';
 import doucheSuitDude from './images/doucheSuitDude.jpg';
-import { MuiThemeProvider, Theme, createMuiTheme } from '@material-ui/core/styles';
-import { NotificationDoNotDisturb } from 'material-ui/svg-icons';
+import {NotificationDoNotDisturb} from 'material-ui/svg-icons';
 
 const suggestions = [
-  {id: '0', name: 'Afghanistan'},
-  {id: '1', name: 'Aland Islands'},
-  {id: '2', name: 'Albania'},
-  {id: '3', name: 'Algeria'},
-  {id: '4', name: 'American Samoa'},
-  {id: '5', name: 'Andorra'},
-  {id: '6', name: 'Angola'},
-  {id: '7', name: 'Anguilla'},
-  {id: '8', name: 'Antarctica'},
-  {id: '9', name: 'Antigua and Barbuda'},
+  {id: '0',  name: 'Afghanistan'},
+  {id: '1',  name: 'Aland Islands'},
+  {id: '2',  name: 'Albania'},
+  {id: '3',  name: 'Algeria'},
+  {id: '4',  name: 'American Samoa'},
+  {id: '5',  name: 'Andorra'},
+  {id: '6',  name: 'Angola'},
+  {id: '7',  name: 'Anguilla'},
+  {id: '8',  name: 'Antarctica'},
+  {id: '9',  name: 'Antigua and Barbuda'},
   {id: '10', name: 'Argentina'},
   {id: '11', name: 'Armenia'},
   {id: '12', name: 'Aruba'},
@@ -94,28 +124,8 @@ interface IDocument {
   code?: string;
 }
 
-interface IName {
-  name: string;
-}
-
-const searcher = arraySearch(['Yes', 'No', 'Maybe', 'Uncertain', 'Definitely Not'], (item?) => item || '');
+const searcher  = arraySearch(['Yes', 'No', 'Maybe', 'Uncertain', 'Definitely Not'], (item?) => item || '');
 const countries = arraySearch(suggestions, (item?) => (item && item.name) || '');
-const state = documentSearch('state');
-const city = documentSearch('city');
-
-// const fld   = autoCompleteField<IName>(suggestions, 'Countries', (item?) => (item && item.name) || '');
-// const state = autoCompleteField<IDocument>('state', 'State');
-// const city  = autoCompleteField<IDocument>('city', 'City', state);
-// const name  = textField('Sandy', 'Name');
-
-// setTimeout(() => { name.error = 'error!!'; }, 1000);
-// setTimeout(() => { name.enabled = false; }, 3000);
-// setTimeout(() => { name.visible = false; }, 5000);
-// setTimeout(() => { name.visible = true; }, 7000);
-// setTimeout(() => { name.enabled = true; }, 9000);
-// setTimeout(() => state.value = 'Douglas', 2000);
-// fld.value = 'Brazil';
-// watch(() => name.value, () => console.log(name.value));
 
 interface IOoga {
   YesNoValue: string;
@@ -130,11 +140,6 @@ interface IOoga {
   time?     : number;
 }
 
-interface IUIState {
-  disabled?: boolean;
-  visible? : boolean;
-}
-
 const ooga: IOoga = observable({
   YesNoValue: 'Yes',
   name      : 'Sandy',
@@ -143,17 +148,9 @@ const ooga: IOoga = observable({
   loading   : false
 });
 
-// watch(() => ooga.date, () => console.log(ooga.date, utc(ooga.date).toTimestampString()));
-
-const uistate: IUIState = observable({});
-
 setTimeout(() => {
   ooga.YesNoValue = 'BLAH';
 }, 4000);
-
-// setTimeout(() => {
-//   uistate.disabled = true;
-// }, 4000);
 
 const BasicExample = (props: any) => {
   return (
@@ -172,22 +169,6 @@ const BasicExample = (props: any) => {
     </Router>
   );
 };
-
-function stateChanged(v: any) {
-  ooga.state = v;
-}
-
-function cityChanged(v: any) {
-  ooga.city = v;
-}
-
-const asFloat = (value: (v: number) => void) => (evt: React.ChangeEvent<HTMLInputElement>) => value(parseFloat(evt.target.value));
-const asInt   = (evt: React.ChangeEvent<HTMLInputElement>) => parseInt(evt.target.value);
-const asText  = (value: (v: string) => void) => (evt: React.ChangeEvent<HTMLInputElement>) => value(evt.target.value);
-
-let updateName = (v?: string) => ooga.name = v;
-const suggestions2 = observable(suggestions);
-// setTimeout(() => { console.log('here'); suggestions2[0].name = 'error!!'; }, 5000);
 
 class LoginDialog extends Modal {
   form: Form = Form.create({
@@ -238,9 +219,6 @@ const LoginFormView = ({form}: {form: typeof loginDialog.form}) => (
   </FormView>
   </div>
 );
-
-// watch(() => loginDialog.form.hasChanges, () => console.log('has changes =', loginDialog.form.hasChanges));
-// watch(() => loginDialog.form.hasErrors, () => console.log('has errors =', loginDialog.form.hasErrors));
 
 const getLoginTitle = (dialog: Modal): JSX.Element => {
   return <div>Login</div>;
@@ -374,73 +352,6 @@ const GridHotkeysDialog = () => (
     </div>
   </ DialogView>
 );
-
-// const testGrid = {
-//   rows: observable([] as any[]),
-//   columns: [
-//     column('product', 'Product', 'text', 'medium'),
-//     column('name', 'Name', 'password', 'large'),
-//     column('name2', 'Name2', 'number'),
-//     column('description', 'Description', {type: 'number', options: {decimals: 2, thousandSeparator: true}}, 'medium'),
-//     column('code', 'Code', {type: 'auto-complete', options: countries}, 'large'),
-//     column('owner', 'Owner', 'text')
-//   ]
-// };
-
-// async function loadGrid(delayms: number) {
-//   ooga.loading = true;
-//   await delay(delayms);
-//   testGrid.rows.set(
-//     { id: 0, product: 'DevExtreme', owner: 'DevExpress' },
-//     { id: 1, product: 'DevExtreme', owner: 'DevExpress', code: {name: 'Aland Islands'} },
-//     { id: 2, product: 'DevExtreme Reactive', owner: 'DevExpress' },
-//     { id: 3, product: 'DevExtreme', owner: 'DevExpress' },
-//     { id: 4, product: 'DevExtreme Reactive', owner: 'DevExpress' },
-//     { id: 5, product: 'DevExtreme', owner: 'DevExpress' },
-//     { id: 6, product: 'DevExtreme Reactive', owner: 'DevExpress' },
-//     { id: 7, product: 'DevExtreme', owner: 'DevExpress' },
-//     { id: 8, product: 'DevExtreme Reactive', owner: 'DevExpress' },
-//     { id: 9, product: 'DevExtreme', owner: 'DevExpress' },
-//     { id: 10, product: 'DevExtreme', owner: 'DevExpress' },
-//   );
-//   ooga.loading = false;
-// }
-
-// loadGrid(0);
-// // setTimeout(() => {
-//   console.log(JSON.stringify(testGrid.rows));
-//   loadGrid(3500 );
-// }
-//   , 10000);
-// loadGrid(6500);
-
-// setTimeout(() => testGrid.rows.push({id: 4, product: 'goober', owner: 'me'}), 4000);
-// setTimeout(() => testGrid.rows.push({id: 5, product: 'goober2', owner: 'me2'}), 8000);
-// setTimeout(() => testGrid.columns.push({name: 'ooga', title: 'The Ooga'}), 4000);
-// setTimeout(() => testGrid.rows.push({id: 6, product: 'goober2', owner: 'me2'}), 10000);
-// setTimeout(() => testGrid.rows[0].product = 'ooga', 6000);
-// setTimeout(() => testGrid.rows[3].product = 'ooga', 12000);
-
-const items1 = {id: '1000', items: observable([])};
-const items2 = {id: '1001', items: observable([])};
-const items3 = {id: '1002', items: observable([])};
-
-function createItems(items: any[], n: number, y: number = 1) {
-  for (let x = 0; x < n; x++) {
-    let id = x + y;
-    items.push({id: '' + id, name: `item ${id.toFixed(2)}`});
-  }
-}
-
-setTimeout(() => (items1 as any).items[0].name = 'ooga', 3000);
-
-createItems(items1.items, 15);
-createItems(items2.items, 15, 50);
-createItems(items3.items, 15, 90);
-
-const items4 = observable([items1, items2, items3]);
-
-// watch(() => items1.items.length, () => console.log('test has changed'));
 
 const confirmation = new Modal('Delete entire hard drive?')
   .action('yes', () => (console.log('no way you chose that'), true), {color: 'primary'})
@@ -660,14 +571,6 @@ console.log(r);
 // setTimeout(() => grid.rows[0].cells['column0'].value = 'booga', 6000);
 // setTimeout(() => grid.columns[3].visible = false, 7000);
 // setTimeout(() => grid.columns[3].visible = true, 8000);
-
-// watch(() => grid.changed, () => {
-//   if (grid.changed) {
-//     console.log('IT HAS CHANGED');
-//   } else {
-//     console.log('IT IS THE SAME');
-//   }
-// });
 
 let employees = [
   {id: '1e',  name: 'Schrute, Dwight',         email: 'testEmail11@test.com',       isActive: true, timeColumn: '7:30', autoCompleteColumn: undefined        , selectColumn: {name: 'Bermuda'}, numberColumn1: 1, numberColumn2: 2, numberColumn3: 3},
@@ -1006,23 +909,6 @@ async function login() {
   let theme = createMuiTheme({typography: {useNextVariants: true}});
   ReactDOM.render(<MuiThemeProvider theme={theme}><BasicExample /></MuiThemeProvider>, document.getElementById('root'));
 }
-
-let id = 0;
-class Test {
-  id: number = id++;
-  enabled    = true;
-  rows       = [];
-  headers    = [];
-  loading    = false;
-  width      = 'calc(100vh - 260px)';
-  height     = '1600px';
-  fixedWidth = '180px';
-  isDraggable: boolean = false;
-  constructor() {
-
-  }
-}
-
 
 login();
 

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.0-beta.141",
+  "version": "1.0.0-beta.145",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.0-beta.141",
+  "version": "1.0.0-beta.145",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/worksight/rewire",
   "dependencies": {
+    "mixin-deep": "^2.0.0",
     "react": "^16.4.2",
     "s-js": "^0.4.9"
   }

--- a/packages/rewire-core/src/observable.ts
+++ b/packages/rewire-core/src/observable.ts
@@ -193,9 +193,9 @@ export function defaultEquals(v1: any, v2: any) {
     return true;
   }
 
-  const undefinedOrNull1 = v1 === undefined || v1 === null;
-  const undefinedOrNull2 = v2 === undefined || v2 === null;
-  if (undefinedOrNull1 && undefinedOrNull2) return true;
+  const undefinedOrNullOrEmpty1 = v1 === undefined || v1 === null || v1 === '';
+  const undefinedOrNullOrEmpty2 = v2 === undefined || v2 === null || v2 === '';
+  if (undefinedOrNullOrEmpty1 && undefinedOrNullOrEmpty2) return true;
   if (Array.isArray(v1) && Array.isArray(v2)) {
     if (v1.length !== v2.length) return false;
     for (let i = 0; i < v1.length; i++) {

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.0-beta.141",
+  "version": "1.0.0-beta.145",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/worksight/rewire",
   "dependencies": {
     "is": "^3.2.1",
-    "rewire-core": "^1.0.0-beta.141"
+    "rewire-core": "^1.0.0-beta.145"
   }
 }

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.0-beta.141",
+  "version": "1.0.0-beta.145",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",
@@ -27,12 +27,11 @@
     "deepmerge": "^3.1.0",
     "fast-deep-equal": "^2.0.1",
     "is": "^3.2.1",
-    "mixin-deep": "^2.0.0",
     "nanoid": "^1.2.3",
     "react": "^16.4.2",
     "resize-observer-polyfill": "^1.5.0",
-    "rewire-common": "^1.0.0-beta.141",
-    "rewire-core": "^1.0.0-beta.141",
-    "rewire-ui": "^1.0.0-beta.141"
+    "rewire-common": "^1.0.0-beta.145",
+    "rewire-core": "^1.0.0-beta.145",
+    "rewire-ui": "^1.0.0-beta.145"
   }
 }

--- a/packages/rewire-grid/src/components/Cell.tsx
+++ b/packages/rewire-grid/src/components/Cell.tsx
@@ -216,26 +216,7 @@ class Cell extends React.PureComponent<CellProps, {}> {
         }
         if (evt.ctrlKey) {
           // delete row(s)
-          let currCell: ICell                    = this.cell;
-          let newCellToSelect: ICell | undefined = this.cell;
-          do {
-            currCell        = newCellToSelect;
-            newCellToSelect = this.grid.adjacentBottomCell(currCell, true);
-          } while (newCellToSelect && newCellToSelect.selected);
-          if (!newCellToSelect) {
-            currCell        = this.cell;
-            newCellToSelect = this.cell;
-            do {
-              currCell        = newCellToSelect;
-              newCellToSelect = this.grid.adjacentTopCell(currCell, true);
-            } while (newCellToSelect && newCellToSelect.selected);
-          }
           this.grid.removeSelectedRows();
-          if (!newCellToSelect) {
-            break;
-          }
-          this.grid.startCell = newCellToSelect;
-          this.grid.selectCells([newCellToSelect]);
           break;
         }
         this.grid.selectedCells.forEach(cell => cell.clear());

--- a/packages/rewire-grid/src/components/Column.tsx
+++ b/packages/rewire-grid/src/components/Column.tsx
@@ -63,8 +63,7 @@ export default class Column extends React.PureComponent<IColumnCellProps> {
 
   render() {
     return <Observe render={() => {
-      let cls = this.column.cls;
-
+      let cls = '';
       let style: React.CSSProperties = {position: 'relative'};
       if (!this.column.visible) {
         style.display    = 'none';
@@ -77,12 +76,8 @@ export default class Column extends React.PureComponent<IColumnCellProps> {
       }
 
       if (this.column.canSort && this.column.sort) {
-        if (cls) {
-          cls += ' sort ' + this.column.sort;
-        } else {
           cls = 'sort ' + this.column.sort;
         }
-      }
 
       return (
         <th

--- a/packages/rewire-grid/src/models/CellModel.ts
+++ b/packages/rewire-grid/src/models/CellModel.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as is from 'is';
 import {IGrid, IColumn, ICell, IRow, IError, IErrorData, TextAlignment, VerticalAlignment, cloneValue} from './GridTypes';
-import { observable, defaultEquals, property, DataSignal } from 'rewire-core';
-import * as deepEqual                                      from 'fast-deep-equal';
-import mixin                                               from 'mixin-deep';
+import {observable, defaultEquals, property, DataSignal} from 'rewire-core';
+import * as deepEqual                                    from 'fast-deep-equal';
+import {replace}                                         from 'rewire-core';
 
 let id = 0;
 export class CellModel implements ICell {
@@ -197,7 +197,7 @@ export class CellModel implements ICell {
   _setValue(value: any) {
     if (this.value === value) return;
     if (is.object(this.value) && is.object(value)) {
-      mixin(this.value, value);
+      replace(this.value, value);
     } else {
       this.value = value;
     }
@@ -307,6 +307,33 @@ export class CellModel implements ICell {
     if (this.hasChanges()) {
       this.setValue(cloneValue(this.row.data[this.column.name]));
     }
+  }
+
+  unselect() {
+    this.selected              = false;
+    this.isTopMostSelection    = false;
+    this.isRightMostSelection  = false;
+    this.isBottomMostSelection = false;
+    this.isLeftMostSelection   = false;
+  }
+
+  findVerticallyNearestCellWithUnselectedRow(): ICell | undefined {
+    let currCell: ICell                    = this;
+    let newCellToSelect: ICell | undefined = this;
+    do {
+      currCell        = newCellToSelect;
+      newCellToSelect = this.grid.adjacentBottomCell(currCell, true);
+    } while (newCellToSelect && newCellToSelect.row.selected);
+    if (!newCellToSelect) {
+      currCell        = this;
+      newCellToSelect = this;
+      do {
+        currCell        = newCellToSelect;
+        newCellToSelect = this.grid.adjacentTopCell(currCell, true);
+      } while (newCellToSelect && newCellToSelect.row.selected);
+    }
+
+    return newCellToSelect;
   }
 }
 

--- a/packages/rewire-grid/src/models/GridTypes.ts
+++ b/packages/rewire-grid/src/models/GridTypes.ts
@@ -102,7 +102,7 @@ export interface IGrid extends IRows, IDisposable {
   _removeGroupRow(rows: any, id: string): void;
   removeRow(id: string): void;
   removeRows(ids: string[]): void;
-  removeSelectedRows(): void;
+  removeSelectedRows(reselect?: boolean): void;
   addRow(row: any, position?: number): IRow;
   _addRow(row: any, position?: number): IRow;
   addRows(rows: any[], position?: number): void;
@@ -276,6 +276,8 @@ export interface ICell extends ICellProperties {
   validate(): void;
   _revert(): void;
   revert(): void;
+  unselect(): void;
+  findVerticallyNearestCellWithUnselectedRow(): ICell | undefined;
 }
 
 export type ICellMap     = {[columnName: string]: ICell};

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.0-beta.141",
+  "version": "1.0.0-beta.145",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
     "react": "^16.4.2",
     "react-beautiful-dnd": "^9.0.2",
     "react-number-format": "^4.0.3",
-    "rewire-common": "^1.0.0-beta.141",
-    "rewire-core": "^1.0.0-beta.141"
+    "rewire-common": "^1.0.0-beta.145",
+    "rewire-core": "^1.0.0-beta.145"
   }
 }

--- a/packages/rewire-ui/src/components/AutoComplete.tsx
+++ b/packages/rewire-ui/src/components/AutoComplete.tsx
@@ -354,7 +354,7 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
     return (
       <Downshift
         defaultHighlightedIndex={0}
-        initialSelectedItem={this.props.selectedItem}
+        selectedItem={this.props.selectedItem}
         itemToString={this.map}
         onInputValueChange={this.handleInputChanged}
         onUserAction={this.handleItemChanged}

--- a/packages/rewire-ui/src/components/NumberField.tsx
+++ b/packages/rewire-ui/src/components/NumberField.tsx
@@ -68,6 +68,7 @@ export interface INumberFieldProps {
   align?                : TextAlignment;
   decimals?             : number;
   fixed?                : boolean;
+  isNumericString?      : boolean;
   thousandSeparator?    : boolean;
   updateOnChange?       : boolean;
   selectOnFocus?        : boolean;
@@ -76,7 +77,7 @@ export interface INumberFieldProps {
   startAdornment?       : JSX.Element;
   endAdornment?         : JSX.Element;
 
-  onValueChange: (value?: number) => void;
+  onValueChange: (value?: number | string) => void;
 }
 
 type NumberFieldProps = WithStyle<ReturnType<typeof styles>, TextFieldProps & INumberFieldProps>;
@@ -87,7 +88,8 @@ class NumberTextField extends React.Component<NumberFieldProps> {
   }
 
   handleValueChanged = (values: any) => {
-    this.props.onValueChange(values.floatValue);
+    let value = this.props.isNumericString ? values.value : values.floatValue;
+    this.props.onValueChange(value);
   }
 
   shouldComponentUpdate(nextProps: NumberFieldProps) {
@@ -133,7 +135,7 @@ class NumberTextField extends React.Component<NumberFieldProps> {
     if (visible === false) {
       return null;
     }
-    let value                       = this.parse(this.props.value);
+    let value                       = this.props.isNumericString ? this.props.value : this.parse(this.props.value);
     const startAdornment            = this.props.startAdornment ? <InputAdornment position='start' classes={{root: this.props.classes.inputAdornmentRoot}}>{this.props.startAdornment}</InputAdornment> : undefined;
     const endAdornment              = this.props.endAdornment ? <InputAdornment position='end' classes={{root: this.props.classes.inputAdornmentRoot}}>{this.props.endAdornment}</InputAdornment> : undefined;
     const inputClassName            = this.props.variant === 'outlined' ? this.props.classes.inputOutlinedInput : this.props.classes.inputInput;
@@ -157,6 +159,7 @@ class NumberTextField extends React.Component<NumberFieldProps> {
           fixedDecimalScale={this.props.fixed}
           format={this.props.format}
           mask={this.props.mask}
+          isNumericString={this.props.isNumericString}
           inputProps={{className: this.props.classes.nativeInput, style: {textAlign: this.props.align || 'left'}}}
           InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: this.props.classes.inputRoot, input: inputClassName, formControl: inputFormControlClassName}}}
           InputLabelProps={{shrink: true, classes: {root: this.props.classes.inputLabelRoot, outlined: this.props.classes.inputLabelRootShrink}}}
@@ -172,7 +175,7 @@ class NumberTextField extends React.Component<NumberFieldProps> {
       <BlurInputHOC
         {...this.props}
         value={value}
-        onValueChange={(v?: number) => this.props.onValueChange(v)}
+        onValueChange={(v?: number | string) => this.props.onValueChange(v)}
         render={(props: NumberFieldProps) => (
           <NumberFormat
             className={props.className}
@@ -181,7 +184,7 @@ class NumberTextField extends React.Component<NumberFieldProps> {
             error={!props.disableErrors && !props.disabled && !!props.error}
             value={props.value}
             label={props.label}
-            onValueChange={(values: any) => props.onChange && props.onChange({target: {value: values.floatValue}} as any)}
+            onValueChange={(values: any) => props.onChange && props.onChange({target: {value: props.isNumericString ? values.value : values.floatValue}} as any)}
             onBlur={props.onBlur}
             autoFocus={props.autoFocus}
             onFocus={this.handleFocus}
@@ -190,6 +193,7 @@ class NumberTextField extends React.Component<NumberFieldProps> {
             fixedDecimalScale={props.fixed}
             format={props.format}
             mask={props.mask}
+            isNumericString={props.isNumericString}
             inputProps={{className: props.classes.nativeInput, style: {textAlign: props.align || 'left'}}}
             InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: props.classes.inputRoot, input: inputClassName, formControl: inputFormControlClassName}}}
             InputLabelProps={{shrink: true, classes: {root: props.classes.inputLabelRoot, outlined: props.classes.inputLabelRootShrink}}}

--- a/packages/rewire-ui/src/components/PhoneField.tsx
+++ b/packages/rewire-ui/src/components/PhoneField.tsx
@@ -32,7 +32,7 @@ class PhoneField extends React.Component<PhoneFieldProps> {
     let phonePlaceholder = phoneFormat && phoneMask && phoneFormat.slice().replace(new RegExp(/#/, 'g'), phoneMask) || placeholder;
 
     return (
-      <NumberField format={phoneFormat} mask={phoneMask} placeholder={phonePlaceholder} {...otherProps} />
+      <NumberField format={phoneFormat} mask={phoneMask} placeholder={phonePlaceholder} isNumericString={true} {...otherProps} />
     );
   }
 }

--- a/packages/rewire-ui/src/models/Form.ts
+++ b/packages/rewire-ui/src/models/Form.ts
@@ -203,8 +203,8 @@ export default class Form {
     this.updateOnChange              = options && options.updateOnChange || false;
     this.validateOnUpdate            = options && options.validateOnUpdate !== undefined ? options.validateOnUpdate : true;
     this.initializeFields(fields);
-    this._initial = initial || {};
-    this.value    = this.initial;
+    this.value    = initial || {};
+    this._initial = Object.assign({}, this.value);
   }
 
   set value(value: ObjectType)  {
@@ -404,7 +404,7 @@ export default class Form {
   }
 
   public reset() {
-    this.value = this.initial;
+    this.value = Object.assign({}, this.initial);
   }
 
   public revert() {


### PR DESCRIPTION
…d and null.

Rewire-Ui: - Autocomplete bug fix. Setting an autocomplete form field value programmatically after the form was loaded was not rendering the change.
    - PhoneField now expects a string, and stores and returns a string (before returned a number).

Rewire-Grid: - The cls property of the column model will no longer apply to the heading for that column, but rather only the data cells.
    - The CellModel _setValue function now uses the replace function from Rewire-core observable to set an object value that already has a value, as to preserve observable functionality. No longer uses mixin.
    - Reverting grid changes that cause the restoration of deleted rows will no longer cause the selected cell to lose focus.
    - Removing rows that are currently selected will now properly remove those rows from the list of currently selected rows, as well as any cells of that row from the list of currently selected cells.
    - The "removeSelectedRows" function now has the reselection of the nearest vertical cell (that was not removed) built in, with the option of turning this default behaviour off.