### PR TITLE
Rewire-Grid: - CellModel _setValue now uses a replace-esque way of se…

### DIFF
--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.0-beta.145",
+  "version": "1.0.0-beta.148",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.0-beta.145",
+  "version": "1.0.0-beta.148",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.0-beta.145",
+  "version": "1.0.0-beta.148",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/worksight/rewire",
   "dependencies": {
     "is": "^3.2.1",
-    "rewire-core": "^1.0.0-beta.145"
+    "rewire-core": "^1.0.0-beta.148"
   }
 }

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.0-beta.145",
+  "version": "1.0.0-beta.148",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",
@@ -30,8 +30,8 @@
     "nanoid": "^1.2.3",
     "react": "^16.4.2",
     "resize-observer-polyfill": "^1.5.0",
-    "rewire-common": "^1.0.0-beta.145",
-    "rewire-core": "^1.0.0-beta.145",
-    "rewire-ui": "^1.0.0-beta.145"
+    "rewire-common": "^1.0.0-beta.148",
+    "rewire-core": "^1.0.0-beta.148",
+    "rewire-ui": "^1.0.0-beta.148"
   }
 }

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.0-beta.145",
+  "version": "1.0.0-beta.148",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
     "react": "^16.4.2",
     "react-beautiful-dnd": "^9.0.2",
     "react-number-format": "^4.0.3",
-    "rewire-common": "^1.0.0-beta.145",
-    "rewire-core": "^1.0.0-beta.145"
+    "rewire-common": "^1.0.0-beta.148",
+    "rewire-core": "^1.0.0-beta.148"
   }
 }


### PR DESCRIPTION
…tting an object value to a new object value, but does so in a slightly modified way, due to delete object props into Object.assign not functioning properly with custom class objects.

    - Bug fix for GridModel focusedCell not being set properly when clicking a new cell. CellModel canFocus() was returning false in this instance before, because the element was already active (due to the click).