### PR TITLE
Rewire-Grid: - Grid / Row / Cell Revert no longer triggers the onValu…

### DIFF
--- a/fuse.js
+++ b/fuse.js
@@ -53,7 +53,9 @@ function runDevelopmentServer() {
     const dist = path.resolve('./build');
 
     function sendFile(req, res) {
-      const p = path.join(dist, req.url);
+      let url = req.url.split('#').shift().split('?').shift().split('/').pop();
+      const p = path.join(dist, url);
+      // const p = path.join(dist, req.url);
       if (fs.existsSync(p)) {
         return res.sendFile(p);
       }

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.0-beta.159",
+  "version": "1.0.0-beta.161",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.0-beta.159",
+  "version": "1.0.0-beta.161",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/src/observable.ts
+++ b/packages/rewire-core/src/observable.ts
@@ -82,7 +82,7 @@ function observable_array(value: ObjectType, eq: EQType, parent?: () => void) {
       if (property === versionProperty) {
         return vsn; // add a version dynamically
       }
-      let   v    = target[property];
+      let v = target[property];
       if (can_observe(v)) {
         v = observable(v, incrementVersion);
         target[property] = v;
@@ -145,11 +145,6 @@ function createHandler(eq: EQType, parent?: () => void) {
         }
       }
 
-      // if (!target.hasOwnProperty(property)) {
-      //   // for getters
-      //   return value;
-      // }
-
       let v = dependencyCache[property];
       if (v) return v();
 
@@ -159,6 +154,19 @@ function createHandler(eq: EQType, parent?: () => void) {
     },
 
     set(target: ObjectType, property: string, value: any, receiver: Object) {
+      // *** Setters on observable objects currently not functioning correctly in some cases. This code doesn't quite fix it for some reason.
+      //     This property calls the objects setter via assigning to the target property, but that is not capturing any updates on assignments
+      //     made in this internal code properly for some cases.
+      // if (!target.hasOwnProperty(property)) {
+      //   // for setters
+      //   let proto    = Object.getPrototypeOf(target);
+      //   let propDesc = Object.getOwnPropertyDescriptor(proto, property);
+      //   if (propDesc && propDesc.set && typeof propDesc.set === 'function') {
+      //     target[property] = value;
+      //     return true;
+      //   }
+      // }
+
       let v = dependencyCache[property];
       if (!v) {
         const oldValue = target[property];

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.0-beta.159",
+  "version": "1.0.0-beta.161",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/worksight/rewire",
   "dependencies": {
     "is": "^3.3.0",
-    "rewire-core": "^1.0.0-beta.159"
+    "rewire-core": "^1.0.0-beta.161"
   }
 }

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.0-beta.159",
+  "version": "1.0.0-beta.161",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",
@@ -30,8 +30,8 @@
     "nanoid": "^2.0.1",
     "react": "^16.8.2",
     "resize-observer-polyfill": "^1.5.1",
-    "rewire-common": "^1.0.0-beta.159",
-    "rewire-core": "^1.0.0-beta.159",
-    "rewire-ui": "^1.0.0-beta.159"
+    "rewire-common": "^1.0.0-beta.161",
+    "rewire-core": "^1.0.0-beta.161",
+    "rewire-ui": "^1.0.0-beta.161"
   }
 }

--- a/packages/rewire-grid/src/components/Column.tsx
+++ b/packages/rewire-grid/src/components/Column.tsx
@@ -38,13 +38,18 @@ export default class Column extends React.PureComponent<IColumnCellProps> {
   }
 
   handleMouseMove = (evt: MouseEvent) => {
+    // Known bug with resizing columns when the set widths of the columns is less than the width of the grid (due to it stretching to fill the screen) i.e. no horizontal scrollbar.
+    // In this case, the resize will cause the column to initially grow larger. No known fix at this point.
     if (this.isResizing) {
       if (this.node.colSpan > 1) {
         let currColumn = this.column;
         let widthToSet = Math.max((this.startOffset + evt.pageX) / this.node.colSpan, 5);
         for (let i = 1; i <= this.node.colSpan; i++) {
+          // let cellWidth    = currColumn.grid.dataRowsByPosition[0].cells[currColumn.name].element.offsetWidth;
+          // widthToSet       = currColumn.width ? widthToSet - (cellWidth - currColumn.width.slice().replace(new RegExp(/px/, 'g'), '')) : widthToSet;
+          // widthToSet       = currColumn.width ? cellWidth + (widthToSet - currColumn.width.slice().replace(new RegExp(/px/, 'g'), '')) : widthToSet;
           currColumn.width = `${widthToSet}px`;
-          currColumn       = currColumn.grid.columnByPos(currColumn.position + 1);
+          currColumn       = currColumn.grid.adjacentRightColumn(currColumn)!;
         }
       } else {
         this.column.width = `${Math.max(this.startOffset + evt.pageX, 5)}px`;

--- a/packages/rewire-grid/src/models/CellModel.ts
+++ b/packages/rewire-grid/src/models/CellModel.ts
@@ -138,7 +138,7 @@ export class CellModel implements ICell {
     return this.column.position;
   }
 
-  _setValue(value: any): boolean {
+  _setValue(value: any, triggerOnValueChangeHandler: boolean = true): boolean {
     if (is.object(this.value) && is.object(value)) {
       if (deepEqual(this.value, value)) return false;
       freeze(() => {
@@ -153,12 +153,12 @@ export class CellModel implements ICell {
       this.value = value;
     }
 
-    this.onValueChange && this.onValueChange(this, value);
+    triggerOnValueChangeHandler && this.onValueChange && this.onValueChange(this, value);
     return true;
   }
 
-  setValue(value: any): boolean {
-    if (this._setValue(value)) {
+  setValue(value: any, triggerOnValueChangeHandler: boolean = true): boolean {
+    if (this._setValue(value, triggerOnValueChangeHandler)) {
       this.validate();
 
       if (this.column.fixed) {
@@ -269,16 +269,16 @@ export class CellModel implements ICell {
     this.grid.inError = this.grid.hasErrors();
   }
 
-  // reverts value without validation or grid changed update
+  // reverts value without validation, onValueChange handler, or grid changed update
   _revert() {
     if (this.hasChanges()) {
-      this._setValue(cloneValue(this.row.originalData[this.column.name]));
+      this._setValue(cloneValue(this.row.originalData[this.column.name]), false);
     }
   }
 
   revert() {
     if (this.hasChanges()) {
-      this.setValue(cloneValue(this.row.originalData[this.column.name]));
+      this.setValue(cloneValue(this.row.originalData[this.column.name]), false);
     }
   }
 

--- a/packages/rewire-grid/src/models/GridModel.ts
+++ b/packages/rewire-grid/src/models/GridModel.ts
@@ -379,6 +379,26 @@ class GridModel implements IGrid, IDisposable {
     return column;
   }
 
+  adjacentRightColumn(column: IColumn): IColumn | undefined {
+    let adjacentRightColumn: IColumn | undefined;
+    let i = 1;
+    do {
+      adjacentRightColumn = this.columnByPos(column.position + i++);
+    } while (adjacentRightColumn && (!adjacentRightColumn.visible || adjacentRightColumn.colSpan === 0));
+
+    return adjacentRightColumn;
+  }
+
+  adjacentLeftColumn(column: IColumn): IColumn | undefined {
+    let adjacentLeftColumn: IColumn | undefined;
+    let i = 1;
+    do {
+      adjacentLeftColumn = this.columnByPos(column.position - i++);
+    } while (adjacentLeftColumn && (!adjacentLeftColumn.visible || adjacentLeftColumn.colSpan === 0));
+
+    return adjacentLeftColumn;
+  }
+
   revert(): void {
     freeze(() => {
       let originalDataRowIds = this.originalDataRowsByPosition.map(row => row.id);
@@ -444,7 +464,12 @@ class GridModel implements IGrid, IDisposable {
     this.selectedCells.forEach((selectedCell: ICell) => {
       selectedCell._revert();
       });
-    this.validate();
+
+    let selectedColumnNames = [...new Set(this.selectedCells.map((cell: ICell) => cell.column.name))];
+    this.selectedRows.forEach((selectedRow: IRow) => {
+      selectedRow.validate(selectedColumnNames);
+      selectedRow.mergeAllColumns();
+    });
     this.changed = this.hasChanges();
   }
 
@@ -453,8 +478,9 @@ class GridModel implements IGrid, IDisposable {
 
     this.selectedRows.forEach((selectedRow: IRow) => {
       selectedRow._revert();
+      selectedRow.validate();
+      selectedRow.mergeAllColumns();
     });
-    this.validate();
     this.changed = this.hasChanges();
   }
 

--- a/packages/rewire-grid/src/models/GridTypes.ts
+++ b/packages/rewire-grid/src/models/GridTypes.ts
@@ -90,6 +90,8 @@ export interface IGrid extends IRows, IDisposable {
   getRowsByRange(rowStart: number, rowEnd: number, allowCollapsed?: boolean): IRow[];
   column(columnName: string): IColumn | undefined;
   columnByPos(columnPosition: number): IColumn | undefined;
+  adjacentRightColumn(column: IColumn): IColumn | undefined;
+  adjacentLeftColumn(column: IColumn): IColumn | undefined;
 
   revert(): void;
   revertSelectedCells(): void;
@@ -187,8 +189,8 @@ export interface IRow extends IDisposable {
   getErrors(): IErrorData[];
   createCell(column: IColumn, value: any, type?: string): ICell;
   clear(columnNames?: string[]): void;
-  _setValue(data: ICellDataMap): boolean;
-  setValue(data: ICellDataMap): boolean;
+  _setValue(data: ICellDataMap, triggerOnValueChangeHandler?: boolean): boolean;
+  setValue(data: ICellDataMap, triggerOnValueChangeHandler?: boolean): boolean;
   mergeAllColumns(): void;
   mergeFixedColumns(): void;
   mergeStandardColumns(): void;
@@ -206,12 +208,12 @@ export interface IGroupRow extends IRow, IRows {
 }
 
 export type IColumnEditor =
-  'text' | 'date' | 'checked' | 'mask' | 'none' |
+  'text' | 'date' | 'checked' | 'none' |
   {type: 'time', options?: {rounding?: number}} |
   {type: 'auto-complete', options: {search: SearchFn<any>, map: MapFn<any>}} |
   {type: 'select', options: {search: SearchFn<any>, map: MapFn<any>}} |
   {type: 'multiselect', options: {search: SearchFn<any>, map: MapFn<any>}} |
-  {type: 'number', options?: {decimals?: number, thousandSeparator?: boolean, fixed?: boolean}} |
+  {type: 'number', options?: {decimals?: number, thousandSeparator?: boolean, fixed?: boolean, allowNegative?: boolean}} |
   {type: 'phone', options?: {format?: string, mask?: string}};
 
 export interface ICellProperties {
@@ -315,8 +317,8 @@ export interface ICell extends ICellProperties {
   canFocus(): boolean;
   setFocus(focus?: boolean): void;
   setElement(element: HTMLTableDataCellElement | undefined): void;
-  _setValue(v: any): boolean;
-  setValue(v: any): boolean;
+  _setValue(v: any, triggerOnValueChangeHandler?: boolean): boolean;
+  setValue(v: any, triggerOnValueChangeHandler?: boolean): boolean;
   validate(): void;
   _revert(): void;
   revert(): void;

--- a/packages/rewire-grid/src/models/RowModel.ts
+++ b/packages/rewire-grid/src/models/RowModel.ts
@@ -76,8 +76,7 @@ export class RowModel implements IRow, IDisposable {
     }
 
     if (!this.grid.loading) {
-      this.mergeFixedColumns();
-      this.mergeStandardColumns();
+      this.mergeAllColumns();
     }
   }
 
@@ -229,24 +228,23 @@ export class RowModel implements IRow, IDisposable {
     this.setValue(rowData);
   }
 
-  _setValue(data: ICellDataMap): boolean {
+  _setValue(data: ICellDataMap, triggerOnValueChangeHandler: boolean = true): boolean {
     if (!data) return false;
     let success = false;
     Object.keys(data).forEach((columnName: string) => {
       let cell = this.cells[columnName];
       if (cell) {
-        success = cell._setValue(data[columnName]) || success;
+        success = cell._setValue(data[columnName], triggerOnValueChangeHandler) || success;
       }
     });
     return success;
   }
 
-  setValue(data: ICellDataMap): boolean {
-    if (this._setValue(data)) {
+  setValue(data: ICellDataMap, triggerOnValueChangeHandler: boolean = true): boolean {
+    if (this._setValue(data, triggerOnValueChangeHandler)) {
       let columnNamesToSet = Object.keys(data).filter((columnName: string) => this.cells[columnName]);
       this.validate(columnNamesToSet);
-      this.mergeFixedColumns();
-      this.mergeStandardColumns();
+      this.mergeAllColumns();
       this.grid.changed = this.grid.hasChanges();
       return true;
     }
@@ -302,11 +300,11 @@ export class RowModel implements IRow, IDisposable {
 
   // reverts value without validation or grid changed update
   _revert() {
-    this._setValue(this._revertHelper());
+    this._setValue(this._revertHelper(), false);
   }
 
   revert() {
-    this.setValue(this._revertHelper());
+    this.setValue(this._revertHelper(), false);
   }
 }
 

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.0-beta.159",
+  "version": "1.0.0-beta.161",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",
@@ -29,7 +29,6 @@
     "@types/classnames": "^2.2.7",
     "@types/color": "^3.0.0",
     "@types/deepmerge": "^2.2.0",
-    "fuse-box": "^3.4.0",
     "@types/material-ui": "^0.21.6",
     "@types/node": "^11.9.4",
     "@types/react": "^16.8.4",
@@ -37,6 +36,7 @@
     "color": "^3.1.0",
     "deepmerge": "^3.2.0",
     "downshift": "^3.2.2",
+    "fuse-box": "^3.4.0",
     "is": "^3.3.0",
     "konva": "^2.6.0",
     "prop-types": "^15.7.2",
@@ -45,7 +45,8 @@
     "react-beautiful-dnd": "^10.0.4",
     "react-color": "^2.17.0",
     "react-number-format": "^4.0.6",
-    "rewire-common": "^1.0.0-beta.159",
-    "rewire-core": "^1.0.0-beta.159"
+    "react-text-mask": "^5.4.3",
+    "rewire-common": "^1.0.0-beta.161",
+    "rewire-core": "^1.0.0-beta.161"
   }
 }

--- a/packages/rewire-ui/src/components/NumberField.tsx
+++ b/packages/rewire-ui/src/components/NumberField.tsx
@@ -70,6 +70,7 @@ export interface INumberFieldProps {
   fixed?                : boolean;
   isNumericString?      : boolean;
   thousandSeparator?    : boolean;
+  allowNegative?        : boolean;
   updateOnChange?       : boolean;
   selectOnFocus?        : boolean;
   endOfTextOnFocus?     : boolean;
@@ -100,6 +101,8 @@ class NumberTextField extends React.Component<NumberFieldProps> {
       (nextProps.format !== this.props.format) ||
       (nextProps.mask !== this.props.mask) ||
       (nextProps.decimals !== this.props.decimals) ||
+      (nextProps.thousandSeparator !== this.props.thousandSeparator) ||
+      (nextProps.allowNegative !== this.props.allowNegative) ||
       (nextProps.fixed !== this.props.fixed) ||
       (nextProps.error !== this.props.error) ||
       (nextProps.label !== this.props.label) ||
@@ -156,6 +159,7 @@ class NumberTextField extends React.Component<NumberFieldProps> {
           autoFocus={this.props.autoFocus}
           onFocus={this.handleFocus}
           thousandSeparator={this.props.thousandSeparator || undefined}
+          allowNegative={this.props.allowNegative}
           decimalScale={this.props.decimals}
           fixedDecimalScale={this.props.fixed}
           format={this.props.format}
@@ -190,6 +194,7 @@ class NumberTextField extends React.Component<NumberFieldProps> {
             autoFocus={props.autoFocus}
             onFocus={this.handleFocus}
             thousandSeparator={props.thousandSeparator || undefined}
+            allowNegative={this.props.allowNegative}
             decimalScale={props.decimals}
             fixedDecimalScale={props.fixed}
             format={props.format}


### PR DESCRIPTION
…eChange handler for the cells that are reverted back to their original values. This is because the initial setting of the cell values also doesn't trigger the handler. setValue and _setValue have been given a "triggerOnValueChangeHandler" flag to facilitate this.

    - Cell merge issue has been fixed when reverting selected cells / rows. Cells that revert to values that generate errors will no longer be incorrectly merged with adjacent cells of the same value.

Rewire-Ui: - NumberField now accepts the option "allowNegative". Can use this to disable the entering of negative numbers.