### PR TITLE
rewire-grid: - Added custom keybinds for grids!, passed in through gr…

### DIFF
--- a/packages/rewire-grid/src/models/CellModel.ts
+++ b/packages/rewire-grid/src/models/CellModel.ts
@@ -31,6 +31,7 @@ export class CellModel implements ICell {
   isRightMostSelection : boolean;
   isBottomMostSelection: boolean;
   isLeftMostSelection  : boolean;
+  keyForEdit?          : string;
 
   static positionCompare(a: ICell, b: ICell): number {
     return a.rowPosition < b.rowPosition ? -1 : a.rowPosition > b.rowPosition ? 1 : a.columnPosition < b.columnPosition ? -1 : a.columnPosition > b.columnPosition ? 1 : 0;
@@ -62,6 +63,7 @@ export class CellModel implements ICell {
     this.isRightMostSelection  = false;
     this.isBottomMostSelection = false;
     this.isLeftMostSelection   = false;
+    this.keyForEdit            = undefined;
   }
 
   set enabled(value: boolean) {
@@ -307,6 +309,16 @@ export class CellModel implements ICell {
     }
 
     return newCellToSelect;
+  }
+
+  performKeybindAction(evt: React.KeyboardEvent<any>): void {
+    let action = this.grid.staticKeybinds[evt.key];
+    if (!action) {
+      action = this.grid.variableKeybinds[evt.key];
+    }
+    if (action) {
+      action(evt, this);
+    }
   }
 }
 

--- a/packages/rewire-grid/src/models/GridModel.ts
+++ b/packages/rewire-grid/src/models/GridModel.ts
@@ -17,6 +17,9 @@ import {
   cloneValue,
   IGridOptions,
   VerticalAlignment,
+  IGridRowKeybindPermissions,
+  IGridStaticKeybinds,
+  IGridVariableKeybinds,
   ICellDataMap,
   IRowOptions,
   IRowData,
@@ -25,6 +28,7 @@ import createRow, {RowModel}   from './RowModel';
 import {ColumnModel}           from './ColumnModel';
 import {CellModel}             from './CellModel';
 import * as is                 from 'is';
+import merge                   from 'deepmerge';
 import {
   observable,
   computed,
@@ -64,6 +68,9 @@ class GridModel implements IGrid, IDisposable {
   multiSelect               : boolean;
   allowMergeColumns         : boolean;
   isMouseDown               : boolean;
+  rowKeybindPermissions     : IGridRowKeybindPermissions;
+  staticKeybinds            : IGridStaticKeybinds;
+  variableKeybinds          : IGridVariableKeybinds;
   startCell?                : ICell;
   changed                   : boolean;
   inError                   : boolean;
@@ -98,12 +105,366 @@ class GridModel implements IGrid, IDisposable {
     this.startCell                  = undefined;
     this.changed                    = false;
     this.inError                    = false;
+    this.rowKeybindPermissions = {
+      insertRow:    options && options.rowKeybindPermissions && options.rowKeybindPermissions.insertRow !== undefined ? options.rowKeybindPermissions.insertRow : true,
+      duplicateRow: options && options.rowKeybindPermissions && options.rowKeybindPermissions.duplicateRow !== undefined ? options.rowKeybindPermissions.duplicateRow : true,
+      deleteRow:    options && options.rowKeybindPermissions && options.rowKeybindPermissions.deleteRow !== undefined ? options.rowKeybindPermissions.deleteRow : true,
+    };
+
+    // put these default keybinds in GridTypes.ts??
+    /**********************************************************************/
+    /************************** Static Keybinds ***************************/
+    /**********************************************************************/
+    this.staticKeybinds = {
+      /******************************/
+      /********* NAVIGATION *********/
+      /******************************/
+      /*-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+       ArrowUp:          Select the first selectable cell above the currently selected and focused cell
+       ArrowDown:        Select the first selectable cell below the currently selected and focused cell
+       ArrowLeft:        Select the first selectable cell to the left of the currently selected and focused cell. If there are none, move up a row and start from the end (right)
+       ArrowRight:       Select the first selectable cell to the right of the currently selected and focused cell. If there are none, move down a row and begin from the start (left)
+      -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+       Shift+ArrowUp:    Select all selectable cells between the starting cell and the first selectable cell above the currently selected and focused cell
+       Shift+ArrowDown:  Select all selectable cells between the starting cell and the first selectable cell below the currently selected and focused cell
+       Shift+ArrowLeft:  Select all selectable cells between the starting cell and the first selectable cell that is to the left of the currently selected and focused cell
+       Shift+ArrowRight: Select all selectable cells between the starting cell and the first selectable cell that is to the right of the currently selected and focused cell
+      -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+       Tab:              Select the first selectable cell to the right of the currently selected and focused cell. If there are none, move down a row and begin from the start (left)
+       Shift+Tab:        Select the first selectable cell to the left of the currently selected and focused cell. If there are none, move up a row and start from the end (right)
+      -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+       Home:             Select the first selectable cell in the currently selected row (left-most)
+       End:              Select the last selectable cell in the currently selected row (right-most)
+      -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+       Ctrl+Home:        Select the first selectable cell grid (top-left-most)
+       Ctrl+End:         Select the last selectable cell grid (bottom-right-most)
+      -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------*/
+      'ArrowUp': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select the first selectable cell above the currently selected and focused cell
+        evt.preventDefault();
+        evt.stopPropagation();
+        let upCell = cell.grid.adjacentTopCell(cell, true);
+        if (!upCell) {
+          return;
+        }
+        cell.grid.startCell = upCell;
+        cell.grid.selectCells([upCell]);
+      },
+
+      'ArrowDown': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select the first selectable cell below the currently selected and focused cell
+        evt.preventDefault();
+        evt.stopPropagation();
+        let downCell = cell.grid.adjacentBottomCell(cell, true);
+        if (!downCell) {
+          return;
+        }
+        cell.grid.startCell = downCell;
+        cell.grid.selectCells([downCell]);
+      },
+
+      'ArrowLeft': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select the first selectable cell to the left of the currently selected and focused cell. If there are none, move up a row and start from the end (right)
+        if (cell.editing) {
+          evt.stopPropagation();
+          if (cell.column.type === 'select' || cell.column.type === 'multiselect' || cell.column.type === 'checked') {
+            evt.preventDefault();
+          }
+          return;
+        }
+        evt.preventDefault();
+        evt.stopPropagation();
+        let prevCell: ICell | undefined;
+        prevCell = cell.grid.previousCell(cell, true);
+        if (!prevCell) {
+          return;
+        }
+        cell.grid.startCell = prevCell;
+        cell.grid.selectCells([prevCell]);
+      },
+
+      'ArrowRight': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select the first selectable cell to the right of the currently selected and focused cell. If there are none, move down a row and begin from the start (left)
+        if (cell.editing) {
+          evt.stopPropagation();
+          if (cell.column.type === 'select' || cell.column.type === 'multiselect' || cell.column.type === 'checked') {
+            evt.preventDefault();
+          }
+          return;
+        }
+        evt.preventDefault();
+        evt.stopPropagation();
+        let nextCell: ICell | undefined;
+        nextCell = cell.grid.nextCell(cell, true);
+        if (!nextCell) {
+          return;
+        }
+        cell.grid.startCell = nextCell;
+        cell.grid.selectCells([nextCell]);
+      },
+
+      'Shift+ArrowUp': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select all selectable cells between the starting cell and the first selectable cell above the currently selected and focused cell
+        evt.preventDefault();
+        evt.stopPropagation();
+        if (!cell.grid.multiSelect) {
+          return;
+        }
+        let upCell = cell.grid.adjacentTopCell(cell, true);
+        if (!upCell) {
+          return;
+        }
+        if (!cell.grid.startCell) {
+          cell.grid.startCell = cell;
+        }
+        cell.grid.selectCellsTo(upCell);
+      },
+
+      'Shift+ArrowDown': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select all selectable cells between the starting cell and the first selectable cell below the currently selected and focused cell
+        evt.preventDefault();
+        evt.stopPropagation();
+        if (!cell.grid.multiSelect) {
+          return;
+        }
+        let downCell = cell.grid.adjacentBottomCell(cell, true);
+        if (!downCell) {
+          return;
+        }
+        if (!cell.grid.startCell) {
+          cell.grid.startCell = cell;
+        }
+        cell.grid.selectCellsTo(downCell);
+      },
+
+      'Shift+ArrowLeft': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select all selectable cells between the starting cell and the first selectable cell that is to the left of the currently selected and focused cell
+        if (cell.editing) {
+          evt.stopPropagation();
+          if (cell.column.type === 'select' || cell.column.type === 'multiselect' || cell.column.type === 'checked') {
+            evt.preventDefault();
+          }
+          return;
+        }
+        evt.preventDefault();
+        evt.stopPropagation();
+        if (!cell.grid.multiSelect) {
+          return;
+        }
+        let leftCell: ICell | undefined;
+        leftCell = cell.grid.adjacentLeftCell(cell, true);
+        if (!leftCell) {
+          return;
+        }
+        if (!cell.grid.startCell) {
+          cell.grid.startCell = cell;
+        }
+        cell.grid.selectCellsTo(leftCell);
+      },
+
+      'Shift+ArrowRight': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select all selectable cells between the starting cell and the first selectable cell that is to the right of the currently selected and focused cell
+        if (cell.editing) {
+          evt.stopPropagation();
+          if (cell.column.type === 'select' || cell.column.type === 'multiselect' || cell.column.type === 'checked') {
+            evt.preventDefault();
+          }
+          return;
+        }
+        evt.preventDefault();
+        evt.stopPropagation();
+        if (!cell.grid.multiSelect) {
+          return;
+        }
+        let rightCell: ICell | undefined;
+        rightCell = cell.grid.adjacentRightCell(cell, true);
+        if (!rightCell) {
+          return;
+        }
+        if (!cell.grid.startCell) {
+          cell.grid.startCell = cell;
+        }
+        cell.grid.selectCellsTo(rightCell);
+      },
+
+      'Tab': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select the first selectable cell to the right of the currently selected and focused cell. If there are none, move down a row and begin from the start (left)
+        evt.preventDefault();
+        evt.stopPropagation();
+        let nextCell = cell.grid.nextCell(cell, true);
+        if (!nextCell) {
+          return;
+        }
+        cell.grid.startCell = nextCell;
+        cell.grid.selectCells([nextCell]);
+      },
+
+      'Shift+Tab': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select the first selectable cell to the left of the currently selected and focused cell. If there are none, move up a row and start from the end (right)
+        evt.preventDefault();
+        evt.stopPropagation();
+        let prevCell = cell.grid.previousCell(cell, true);
+        if (!prevCell) {
+          return;
+        }
+        cell.grid.startCell = prevCell;
+        cell.grid.selectCells([prevCell]);
+      },
+
+      'Home': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select the first selectable cell in the currently selected row (left-most)
+        if (cell.editing) {
+          return;
+        }
+        evt.preventDefault();
+        evt.stopPropagation();
+        let firstCellInRow = cell.grid.firstCellInRow(cell.row, true);
+        if (firstCellInRow) {
+          cell.grid.selectCells([firstCellInRow]);
+        }
+      },
+
+      'End': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select the last selectable cell in the currently selected row (right-most)
+        if (cell.editing) {
+          return;
+        }
+        evt.preventDefault();
+        evt.stopPropagation();
+        let lastCellInRow = cell.grid.lastCellInRow(cell.row, true);
+        if (lastCellInRow) {
+          cell.grid.selectCells([lastCellInRow]);
+        }
+      },
+
+      'Ctrl+Home': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select the first selectable cell grid (top-left-most)
+        if (cell.editing) {
+          return;
+        }
+        evt.preventDefault();
+        evt.stopPropagation();
+        let firstCell = cell.grid.firstCell(true);
+        if (firstCell) {
+          cell.grid.selectCells([firstCell]);
+        }
+      },
+
+      'Ctrl+End': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Select the last selectable cell grid (bottom-right-most)
+        if (cell.editing) {
+          return;
+        }
+        evt.preventDefault();
+        evt.stopPropagation();
+        let lastCell = cell.grid.lastCell(true);
+        if (lastCell) {
+          cell.grid.selectCells([lastCell]);
+        }
+      },
+
+      /******************************/
+      /********** Edit Mode *********/
+      /******************************/
+      /*-----------------------------------------------------------------------------------------------------
+       Escape: If editing, exit editing mode without changes, and re-select cell. Otherwise, remove selection
+       Enter:  Exit editing mode with changes, and re-select cell
+       F2:     Enter editing mode on selected cell
+      -----------------------------------------------------------------------------------------------------*/
+      'Escape': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // If editing, exit editing mode without changes, and re-select cell. Otherwise, remove selection
+        evt.preventDefault();
+        evt.stopPropagation();
+        if (cell.editing) {
+          cell.grid.editCell(undefined);
+          setTimeout(() => {
+            cell.setFocus();
+          }, 0);
+        } else {
+          cell.grid.selectCells([]);
+          cell.setFocus(false);
+        }
+      },
+
+      'Enter': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Exit editing mode with changes, and re-select cell
+        evt.preventDefault();
+        evt.stopPropagation();
+        if (cell.column.type === 'multiselect') {
+          return;
+        }
+        cell.grid.editCell(undefined);
+        cell.setFocus();
+      },
+
+      'F2': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Enter editing mode on selected cell
+        evt.preventDefault();
+        evt.stopPropagation();
+        if (cell.enabled && !cell.readOnly && cell.editable && cell.column.editor) {
+          cell.keyForEdit = undefined;
+          cell.grid.editCell(cell);
+        }
+      },
+
+      /******************************/
+      /******** Miscellaneous *******/
+      /******************************/
+      /*----------------------------
+       Ctrl+C: Copy selected cell(s)
+      -----------------------------*/
+      'Ctrl+C': (evt: React.KeyboardEvent<any>, cell: ICell) => {
+        // Copy selected cell(s)
+        if (cell.editing) {
+          return;
+        }
+        evt.preventDefault();
+        evt.stopPropagation();
+        cell.grid.copy();
+      },
+    };
+
+    /**********************************************************************/
+    /********************* Default Variable Keybinds **********************/
+    /**********************************************************************/
+    const defaultVariableKeybinds: IGridVariableKeybinds = {
+      /******************************/
+      /*** Cell Value Manipulation **/
+      /******************************/
+      /*-----------------------------------------------------------------
+       Ctrl+R:       Revert selected cell(s) to their original values
+         Ctrl+U:       Revert selected row(s) to their original values
+         Ctrl+Shift+U: Revert grid to its original value (data cells only)
+         Ctrl+X:       Cut selected cell(s)
+         Ctrl+V:       Paste to selected cell(s)
+         Delete:       Delete value(s) of selected cell(s)
+      -----------------------------------------------------------------*/
+      'Ctrl+R'      : (evt: React.KeyboardEvent<any>, cell: ICell) => { if (cell.editing) { return; } cell.grid.revertSelectedCells(); evt.stopPropagation(); evt.preventDefault(); },
+      'Ctrl+U'      : (evt: React.KeyboardEvent<any>, cell: ICell) => { if (cell.editing) { return; } cell.grid.revertSelectedRows();  evt.stopPropagation(); evt.preventDefault(); },
+      'Ctrl+Shift+U': (evt: React.KeyboardEvent<any>, cell: ICell) => { if (cell.editing) { return; } cell.grid.revert();              evt.stopPropagation(); evt.preventDefault(); },
+      'Ctrl+X'      : (evt: React.KeyboardEvent<any>, cell: ICell) => { if (cell.editing) { return; } cell.grid.cut();                 evt.stopPropagation(); evt.preventDefault(); },
+      'Ctrl+V'      : (evt: React.KeyboardEvent<any>, cell: ICell) => { if (cell.editing) { return; } cell.grid.paste();               evt.stopPropagation(); evt.preventDefault(); },
+      'Delete'      : (evt: React.KeyboardEvent<any>, cell: ICell) => { if (cell.editing) { return; } cell.grid.clearSelectedCells();  evt.stopPropagation(); evt.preventDefault(); },
+
+      /******************************/
+      /*** Grid Row Manipulation ****/
+      /******************************/
+      /*---------------------------------------------------
+       Ctrl+Insert: Insert new row below selected row(s)
+         Ctrl+D:      Duplicate selected row(s) below them
+         Ctrl+Delete: Delete selected row(s)
+      ---------------------------------------------------*/
+      'Ctrl+Insert' : (evt: React.KeyboardEvent<any>, cell: ICell) => { if (cell.editing) { return; } this.rowKeybindPermissions.insertRow && cell.grid.insertRowAtSelection();     evt.stopPropagation(); evt.preventDefault(); },
+      'Ctrl+D'      : (evt: React.KeyboardEvent<any>, cell: ICell) => { if (cell.editing) { return; } this.rowKeybindPermissions.duplicateRow && cell.grid.duplicateSelectedRows(); evt.stopPropagation(); evt.preventDefault(); },
+      'Ctrl+Delete' : (evt: React.KeyboardEvent<any>, cell: ICell) => { if (cell.editing) { return; } this.rowKeybindPermissions.deleteRow && cell.grid.removeSelectedRows();       evt.stopPropagation(); evt.preventDefault(); },
+    };
+
+    this.variableKeybinds = merge(defaultVariableKeybinds, options && options.variableKeybinds || {}) as IGridVariableKeybinds;
   }
 
   setContentElement(element: HTMLDivElement | undefined) {
     this._contentElement(element);
   }
-
   get contentElement(): HTMLDivElement | undefined {
     return this._contentElement();
   }
@@ -489,6 +850,16 @@ class GridModel implements IGrid, IDisposable {
       selectedRow.mergeAllColumns();
     });
     this.changed = this.hasChanges();
+  }
+
+  clear() {
+    this.dataRowsByPosition.forEach((row: IRow) => {
+      row.clear();
+    });
+  }
+
+  clearSelectedCells() {
+    this.selectedCells.forEach(cell => cell.clear());
   }
 
   _removeGroupRow(iterator: IterableIterator<IRowIteratorResult>, id: string): void {

--- a/packages/rewire-grid/src/models/GridTypes.ts
+++ b/packages/rewire-grid/src/models/GridTypes.ts
@@ -16,6 +16,45 @@ export interface IDisposable {
 export type SortDirection     = 'ascending' | 'descending';
 export type TextAlignment     = 'left' | 'center' | 'right';
 export type VerticalAlignment = 'top' | 'middle' | 'bottom';
+export interface IGridRowKeybindPermissions {
+  insertRow: boolean;
+  duplicateRow: boolean;
+  deleteRow: boolean;
+}
+
+export type GridKeybindAction = (evt: React.KeyboardEvent<any>, cell: ICell) => void;
+export interface IGridStaticKeybinds {
+  'ArrowUp': GridKeybindAction;
+  'ArrowDown': GridKeybindAction;
+  'ArrowLeft': GridKeybindAction;
+  'ArrowRight': GridKeybindAction;
+  'Shift+ArrowUp': GridKeybindAction;
+  'Shift+ArrowDown': GridKeybindAction;
+  'Shift+ArrowLeft': GridKeybindAction;
+  'Shift+ArrowRight': GridKeybindAction;
+  'Tab': GridKeybindAction;
+  'Shift+Tab': GridKeybindAction;
+  'Home': GridKeybindAction;
+  'End': GridKeybindAction;
+  'Ctrl+Home': GridKeybindAction;
+  'Ctrl+End': GridKeybindAction;
+  'Escape': GridKeybindAction;
+  'Enter': GridKeybindAction;
+  'F2': GridKeybindAction;
+  'Ctrl+C': GridKeybindAction;
+}
+export interface IGridVariableKeybinds {
+  'Ctrl+R': GridKeybindAction;
+  'Ctrl+U': GridKeybindAction;
+  'Ctrl+Shift+U': GridKeybindAction;
+  'Ctrl+X': GridKeybindAction;
+  'Ctrl+V': GridKeybindAction;
+  'Delete': GridKeybindAction;
+  'Ctrl+Insert': GridKeybindAction;
+  'Ctrl+D': GridKeybindAction;
+  'Ctrl+Delete': GridKeybindAction;
+  [keybind: string]: GridKeybindAction;
+}
 
 export interface IGrid extends IRows, IDisposable {
   id                        : number;
@@ -46,6 +85,9 @@ export interface IGrid extends IRows, IDisposable {
   changed                   : boolean;
   inError                   : boolean;
   contentElement?           : HTMLDivElement;
+  rowKeybindPermissions     : IGridRowKeybindPermissions;
+  staticKeybinds            : IGridStaticKeybinds;
+  variableKeybinds          : IGridVariableKeybinds;
 
   setContentElement(element: HTMLDivElement | undefined): void;
 
@@ -97,6 +139,8 @@ export interface IGrid extends IRows, IDisposable {
   revert(): void;
   revertSelectedCells(): void;
   revertSelectedRows(): void;
+  clear(): void;
+  clearSelectedCells(): void;
   get(): ICellDataMap[];
   getChanges(): ICellDataMap[];
   set(data: (IRowData | undefined)[]): void;
@@ -130,7 +174,8 @@ export interface IGridOptions {
   multiSelect?         : boolean;
   allowMergeColumns?   : boolean;
   groupBy?             : string[];
-  // rowHotkeyPermissions?: IGridRowHotkeyPermissions;
+  rowKeybindPermissions?: IGridRowKeybindPermissions;
+  variableKeybinds?     : {[keybind: string]: GridKeybindAction};
 }
 
 export interface IGridColors {
@@ -311,6 +356,7 @@ export interface ICell extends ICellProperties {
   isRightMostSelection : boolean;
   isBottomMostSelection: boolean;
   isLeftMostSelection  : boolean;
+  keyForEdit?          : string;
 
   hasChanges(): boolean;
   hasErrors(): boolean;
@@ -328,6 +374,7 @@ export interface ICell extends ICellProperties {
   revert(): void;
   unselect(): void;
   findVerticallyNearestCellWithUnselectedRow(): ICell | undefined;
+  performKeybindAction(evt: React.KeyboardEvent<any>): void;
 }
 
 export type ICellMap     = {[columnName: string]: ICell};


### PR DESCRIPTION
…id options as the object "variableKeybinds", whose keys are the keybinds ex "Shift+Y" or "Ctr+lZ" or "B", etc, and values are functions that perform the desired action. These variable keybinds cannot be any keybinds that are defined as "Static Keybinds" in Cell.tsx, but can override any default keybinds defined under "Variable Keybinds". "Static Keybinds" are primary grid navigation operations, but also includes copying cell(s).