### PR TITLE
Grid cell merging fix for column visibility toggling. New default clearing of selection when clicking outside grids.

### DIFF
--- a/examples/src/Application.tsx
+++ b/examples/src/Application.tsx
@@ -721,8 +721,8 @@ const _Home = (props: any) => <Observe render={() => (
         </DialogView>
         <div style={{overflow: 'auto', padding: 10, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center'}}>
           <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
-            <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => grid.selectCellByPos(0, 4)}>Select Cell</Button>
-            <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => grid.selectCellsByRange(1, 4, 3, 5)}>Select Cells</Button>
+            <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => setTimeout(() => grid.selectCellByPos(0, 4), 0)}>Select Cell</Button>
+            <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => setTimeout(() => grid.selectCellsByRange(1, 4, 3, 5), 0)}>Select Cells</Button>
             <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => {
               grid.addRow({id: 'newRow-' + Math.random() * 2000, data: {column2: 'RC 2-1', column3: 'RC 3-1'}});
               employeesGrid1.addRow({id: 'newRow-' + Math.random() * 2000, data: {name: 'New Employee', email: 'employeeEmail@test.com'}});
@@ -742,20 +742,21 @@ const _Home = (props: any) => <Observe render={() => (
             </Button>
           </div>
           <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
+            <Observe render={() => (<Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => { grid.column('column1')!.visible = !grid.column('column1')!.visible; }}> Toggle Column</Button>)} />
             <Observe render={() => (<Button style={{margin: '0px 15px 10px 0px'}} variant='contained' disabled={!grid.changed} onClick={() => grid.revert()}>Enabled if has Changes. Reverts Changes</Button>)} />
             <Observe render={() => (<Button style={{margin: '0px 15px 10px 0px'}} variant='contained' disabled={!grid.inError}>Enabled if has Errors</Button>)} />
             <Observe render={() => (<Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => console.log(grid.get())}> Save All</Button>)} />
             <Observe render={() => (<Button style={{margin: '0px 0px 10px 0px'}} variant='contained' onClick={() => console.log(grid.getChanges())}> Save Changes</Button>)} />
           </div>
           <Paper style={{padding: 20, width: '80%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', marginBottom: '20px'}}>
-            <Observe render={() => (<Grid grid={grid} gridFontSizes={{header: '0.9rem', body: '0.85rem', groupRow: '0.8rem'}} style={{height: '650px'}} />)} />
+            <Observe render={() => (<Grid grid={grid} gridFontSizes={{header: '0.9rem', body: '0.85rem', groupRow: '0.8rem'}} style={{height: '650px'}} onClick={(evt: React.MouseEvent<any>) => { employeesGrid1.clearSelection(); employeesGrid2.clearSelection(); }} />)} />
           </Paper>
           <Paper style={{padding: 20, width: '80%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center'}}>
             <div style={{display: 'flex', marginBottom: '10px'}}>
               <Button onClick={() => mode.gridMode = 'employees1'} variant='outlined'>Grid 1</Button>
               <Button onClick={() => mode.gridMode = 'employees2'} variant='outlined'>Grid 2</Button>
             </div>
-            <Grid key={mode.gridMode} grid={mode.gridMode === 'employees1' ? employeesGrid1 : employeesGrid2} gridFontSizes={{header: '0.95rem', body: '0.9rem', groupRow: '0.8rem'}} style={{height: '400px'}} />
+            <Grid key={mode.gridMode} grid={mode.gridMode === 'employees1' ? employeesGrid1 : employeesGrid2} gridFontSizes={{header: '0.95rem', body: '0.9rem', groupRow: '0.8rem'}} style={{height: '400px'}} onClick={(evt: React.MouseEvent<any>) => { grid.clearSelection(); mode.gridMode === 'employees1' ? employeesGrid2.clearSelection() : employeesGrid1.clearSelection(); }} />
           </Paper>
         </div>
       </div>

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.0-beta.176",
+  "version": "1.0.0-beta.177",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.0-beta.176",
+  "version": "1.0.0-beta.177",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.0-beta.176",
+  "version": "1.0.0-beta.177",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./es6-lib.js",
   "typings": "./src/index.ts",
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/worksight/rewire",
   "dependencies": {
     "is": "^3.3.0",
-    "rewire-core": "^1.0.0-beta.176"
+    "rewire-core": "^1.0.0-beta.177"
   }
 }

--- a/packages/rewire-graphql/src/types.ts
+++ b/packages/rewire-graphql/src/types.ts
@@ -33,7 +33,7 @@ export interface IQueryResponse {
 
 export interface IClient {
   cache: ICache;
-  bearer: string;
+  bearer?: string;
 
   executeQuery   (queryObject: IQuery, headers?: object, skipCache?: boolean): Promise<IQueryResponse>;
   query          (query: GQL, variables?: object, headers?: object): Promise<IQueryResponse>;

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.0-beta.176",
+  "version": "1.0.0-beta.177",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",
@@ -30,8 +30,8 @@
     "nanoid": "^2.0.1",
     "react": "^16.8.4",
     "resize-observer-polyfill": "^1.5.1",
-    "rewire-common": "^1.0.0-beta.176",
-    "rewire-core": "^1.0.0-beta.176",
-    "rewire-ui": "^1.0.0-beta.176"
+    "rewire-common": "^1.0.0-beta.177",
+    "rewire-core": "^1.0.0-beta.177",
+    "rewire-ui": "^1.0.0-beta.177"
   }
 }

--- a/packages/rewire-grid/src/components/Cell.tsx
+++ b/packages/rewire-grid/src/components/Cell.tsx
@@ -197,8 +197,6 @@ class Cell extends React.PureComponent<CellProps, {}> {
     } else {
       this.grid.selectCells([this.cell]);
     }
-
-    evt.stopPropagation();
   }
 
   handleFocus = (evt: React.FocusEvent<any>) => {

--- a/packages/rewire-grid/src/components/Column.tsx
+++ b/packages/rewire-grid/src/components/Column.tsx
@@ -1,6 +1,6 @@
-import {IColumn, ICell} from '../models/GridTypes';
-import * as React       from 'react';
-import {Observe}        from 'rewire-core';
+import {IColumn, ICell}                   from '../models/GridTypes';
+import * as React                         from 'react';
+import {Observe, disposeOnUnmount, watch} from 'rewire-core';
 
 export interface IColumnCellProps {
   cell: ICell;
@@ -17,12 +17,18 @@ export default class Column extends React.PureComponent<IColumnCellProps> {
     this.startOffset = 0;
     this.isResizing  = false;
     this.column      = this.props.cell.column;
+
+    disposeOnUnmount(this, () => {
+      watch(() => this.column.visible, () => {
+        this.column.grid.mergeColumns();
+      });
+    });
   }
 
   handleMouseUp = (evt: MouseEvent) => {
     if (!this.node) return;
     this.isResizing = false;
-    document.removeEventListener('mouseup', this.handleMouseMove, true);
+    document.removeEventListener('mouseup', this.handleMouseUp, true);
     document.removeEventListener('mousemove', this.handleMouseMove, true);
     evt.preventDefault();
   }

--- a/packages/rewire-grid/src/models/GridModel.ts
+++ b/packages/rewire-grid/src/models/GridModel.ts
@@ -72,6 +72,7 @@ class GridModel implements IGrid, IDisposable {
   multiSelect               : boolean;
   allowMergeColumns         : boolean;
   isMouseDown               : boolean;
+  clearSelectionOnBlur      : boolean;
   rowKeybindPermissions     : IGridRowKeybindPermissions;
   staticKeybinds            : IGridStaticKeybinds;
   variableKeybinds          : IGridVariableKeybinds;
@@ -104,6 +105,7 @@ class GridModel implements IGrid, IDisposable {
     this.isDraggable                = options && options.isDraggable !== undefined ? options.isDraggable : false;
     this.multiSelect                = options && options.multiSelect !== undefined ? options.multiSelect : false;
     this.allowMergeColumns          = options && options.allowMergeColumns !== undefined ? options.allowMergeColumns : false;
+    this.clearSelectionOnBlur       = options && options.clearSelectionOnBlur !== undefined ? options.clearSelectionOnBlur : true;
     this.clipboard                  = [];
     this.isMouseDown                = false;
     this.startCell                  = undefined;
@@ -1014,6 +1016,7 @@ class GridModel implements IGrid, IDisposable {
     let currentCells = this.selectedCells;
 
     if (currentCells.length <= 0 && cells.length <= 0) {
+      this.focusedCell && this.focusedCell.setFocus(false);
       return;
     }
     // let firstGroupRow = this.rows[0];
@@ -1068,8 +1071,9 @@ class GridModel implements IGrid, IDisposable {
     });
 
     if (this.selectedCells.length <= 0) {
+      this.focusedCell && this.focusedCell.setFocus(false);
       return;
-      }
+    }
 
     let cToFocus: ICell | undefined = cellToFocus ? cellToFocus : cellsToSelect[cellsToSelect.length - 1];
 

--- a/packages/rewire-grid/src/models/GridTypes.ts
+++ b/packages/rewire-grid/src/models/GridTypes.ts
@@ -84,6 +84,7 @@ export interface IGrid extends IRows, IDisposable {
   startCell?                : ICell;
   changed                   : boolean;
   inError                   : boolean;
+  clearSelectionOnBlur?     : boolean;
   contentElement?           : HTMLDivElement;
   rowKeybindPermissions     : IGridRowKeybindPermissions;
   staticKeybinds            : IGridStaticKeybinds;
@@ -167,13 +168,14 @@ export interface IGrid extends IRows, IDisposable {
 }
 
 export interface IGridOptions {
-  enabled?             : boolean;
-  readOnly?            : boolean;
-  verticalAlign?       : VerticalAlignment;
-  isDraggable?         : boolean;
-  multiSelect?         : boolean;
-  allowMergeColumns?   : boolean;
-  groupBy?             : string[];
+  enabled?              : boolean;
+  readOnly?             : boolean;
+  verticalAlign?        : VerticalAlignment;
+  isDraggable?          : boolean;
+  multiSelect?          : boolean;
+  allowMergeColumns?    : boolean;
+  clearSelectionOnBlur? : boolean;
+  groupBy?              : string[];
   rowKeybindPermissions?: IGridRowKeybindPermissions;
   variableKeybinds?     : {[keybind: string]: GridKeybindAction};
 }

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.0-beta.176",
+  "version": "1.0.0-beta.177",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
     "react-color": "^2.17.0",
     "react-number-format": "^4.0.6",
     "react-text-mask-hoc": "^0.11.0",
-    "rewire-common": "^1.0.0-beta.176",
-    "rewire-core": "^1.0.0-beta.176"
+    "rewire-common": "^1.0.0-beta.177",
+    "rewire-core": "^1.0.0-beta.177"
   }
 }


### PR DESCRIPTION
Rewire-grid: - Grid cell merging is now recalculated whenever columns have their visibility toggled.
    - Grid rows now properly re-render with the new updated value for their visibleColumns prop whenever columns are made visible / not visible. This fixes rendering issues for grids with group rows.
    - Grids now clear cell selection when clicking outside the grid by default. To disable this feature, pass in the "clearSelectionOnBlur" property of the IGridOptions object with a value of false. Grid options are supplied to the grid create function when creating the grid model.