### PR TITLE
General:  - Examples HomeView page now has functioning select cell an…

### DIFF
--- a/examples/src/HomeView.tsx
+++ b/examples/src/HomeView.tsx
@@ -414,6 +414,7 @@ export const HomeView = (props: any) => <Observe render={() => (
         </Button>
       </div>
       <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
+        <Observe render={() => (<Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => { grid.column('column1')!.visible = !grid.column('column1')!.visible; }}> Toggle Column</Button>)} />
         <Observe render={() => (<Button style={{margin: '0px 15px 10px 0px'}} variant='contained' disabled={!grid.changed} onClick={() => grid.revert()}>Enabled if has Changes. Reverts Changes</Button>)} />
         <Observe render={() => (<Button style={{margin: '0px 15px 10px 0px'}} variant='contained' disabled={!grid.inError}>Enabled if has Errors</Button>)} />
         <Observe render={() => (<Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => console.log(grid.get())}> Save All</Button>)} />
@@ -429,7 +430,7 @@ export const HomeView = (props: any) => <Observe render={() => (
           <Button onClick={() => mode.gridMode = 'employees1'} style={{marginRight: '10px'}} variant='outlined'>Grid 1</Button>
           <Button onClick={() => mode.gridMode = 'employees2'}                               variant='outlined'>Grid 2</Button>
         </div>
-          <Grid key={mode.gridMode} grid={mode.gridMode === 'employees1' ? employeesGrid1 : employeesGrid2} gridFontSizes={{header: '0.95rem', body: '0.9rem', groupRow: '0.8rem'}} style={{height: '400px'}} />
+        <Grid key={mode.gridMode} grid={mode.gridMode === 'employees1' ? employeesGrid1 : employeesGrid2} gridFontSizes={{header: '0.95rem', body: '0.9rem', groupRow: '0.8rem'}} style={{height: '400px'}} />
       </Paper>
     </div>
   </div>

--- a/examples/src/index.html
+++ b/examples/src/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en"><![endif]-->
-<html>
+<html style='height: 100%'>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -11,8 +11,8 @@
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
-  <body>
-    <div id='root' ></div>
+  <body style='height: 100%'>
+    <div id='root' style='height: 100%'></div>
     <script src="./main.ts"></script>
   </body>
 </html>

--- a/packages/rewire-grid/src/components/Cell.tsx
+++ b/packages/rewire-grid/src/components/Cell.tsx
@@ -159,13 +159,9 @@ class Cell extends React.PureComponent<CellProps, {}> {
       return;
     }
 
-    this.grid.isMouseDown = true;
     if (!evt.shiftKey || !this.grid.startCell) {
       this.grid.startCell = this.cell;
     }
-
-    evt.preventDefault();
-    evt.stopPropagation();
   }
 
   handleMouseEnter = (evt: React.MouseEvent<any>) => {
@@ -173,6 +169,9 @@ class Cell extends React.PureComponent<CellProps, {}> {
       return;
     }
 
+    if (!this.grid.startCell) {
+      this.grid.startCell = this.cell;
+    }
     this.grid.selectCellsTo(this.cell, evt.ctrlKey);
   }
 
@@ -197,6 +196,8 @@ class Cell extends React.PureComponent<CellProps, {}> {
     } else {
       this.grid.selectCells([this.cell]);
     }
+
+    evt.stopPropagation();
   }
 
   handleFocus = (evt: React.FocusEvent<any>) => {

--- a/packages/rewire-grid/src/components/Column.tsx
+++ b/packages/rewire-grid/src/components/Column.tsx
@@ -40,7 +40,6 @@ export default class Column extends React.PureComponent<IColumnCellProps> {
     document.addEventListener('mouseup', this.handleMouseUp, true);
     document.addEventListener('mousemove', this.handleMouseMove, true);
     evt.preventDefault();
-    evt.stopPropagation();
   }
 
   handleMouseMove = (evt: MouseEvent) => {

--- a/packages/rewire-grid/src/models/GridModel.ts
+++ b/packages/rewire-grid/src/models/GridModel.ts
@@ -483,7 +483,7 @@ class GridModel implements IGrid, IDisposable {
     if (this.focusedCell) {
       this.focusedCell.setFocus();
     }
-        }
+  }
 
   revertSelectedCells() {
     if (this.selectedCells.length <= 0) return;
@@ -1231,6 +1231,7 @@ class GridModel implements IGrid, IDisposable {
   }
 
   clearSelection() {
+    this.startCell = undefined;
     this.editCell(undefined);
     this.selectCells([]);
   }

--- a/packages/rewire-ui/src/components/AutoComplete.tsx
+++ b/packages/rewire-ui/src/components/AutoComplete.tsx
@@ -223,6 +223,7 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
     const { getMenuProps, isOpen, children, classes } = options;
     const menuProps = {
       onMouseDown: this.handleMenuMouseDown,
+      onMouseUp: this.handleMenuMouseUp,
       onClick: this.handleMenuClick,
       onDoubleClick: this.handleMenuDoubleClick,
     };
@@ -288,8 +289,9 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
             });
             return;
           }
-          event.stopPropagation();
           event.preventDefault();
+          event.stopPropagation();
+          event.nativeEvent.stopImmediatePropagation();
         }
         break;
       case 37:
@@ -298,24 +300,34 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
       case 40:
         if (this.state.suggestions.length > 0) {
           event.stopPropagation();
+          event.nativeEvent.stopImmediatePropagation();
         }
         break;
     }
   }
 
   handleMenuMouseDown = (event: React.MouseEvent<any>) => {
-    event.stopPropagation();
     event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
+  }
+
+  handleMenuMouseUp = (event: React.MouseEvent<any>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
   }
 
   handleMenuClick = (event: React.MouseEvent<any>) => {
-    event.stopPropagation();
     event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
   }
 
   handleMenuDoubleClick = (event: React.MouseEvent<any>) => {
-    event.stopPropagation();
     event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
   }
 
   componentWillReceiveProps (nextProps: ICustomProps<T>) {

--- a/packages/rewire-ui/src/components/ColorPickerDialog.tsx
+++ b/packages/rewire-ui/src/components/ColorPickerDialog.tsx
@@ -3,6 +3,7 @@ import {SketchPicker}          from 'react-color';
 import Popover                 from '@material-ui/core/Popover';
 import {Theme}                 from '@material-ui/core/styles';
 import {WithStyle, withStyles} from './styles';
+import './colorPickerDialog.css';
 
 const styles = (theme: Theme) => ({
 });

--- a/packages/rewire-ui/src/components/Select.tsx
+++ b/packages/rewire-ui/src/components/Select.tsx
@@ -186,41 +186,54 @@ class SelectInternal<T> extends React.Component<SelectInternalProps<T>, any> {
           this.props.onSelectItem && this.props.onSelectItem(valueToSelect);
         }
         this.setState({isOpen: false});
-        event.stopPropagation();
         event.preventDefault();
+        event.stopPropagation();
+        event.nativeEvent.stopImmediatePropagation();
       case 13:
       case 37:
       case 38:
       case 39:
       case 40:
         event.stopPropagation();
+        event.nativeEvent.stopImmediatePropagation();
         break;
     }
   }
 
   handleMenuKeyPress = (event: React.KeyboardEvent<any>) => {
-    event.stopPropagation();
     event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
   }
 
   handleMenuMouseEnter = (event: React.MouseEvent<any>) => {
-    event.stopPropagation();
     event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
   }
 
   handleMenuMouseDown = (event: React.MouseEvent<any>) => {
-    event.stopPropagation();
     event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
+  }
+
+  handleMenuMouseUp = (event: React.MouseEvent<any>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
   }
 
   handleMenuClick = (event: React.MouseEvent<any>) => {
-    event.stopPropagation();
     event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
   }
 
   handleMenuDoubleClick = (event: React.MouseEvent<any>) => {
-    event.stopPropagation();
     event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
   }
 
   handleChanged = (event: ChangeEvent<any>) => {
@@ -266,6 +279,7 @@ class SelectInternal<T> extends React.Component<SelectInternalProps<T>, any> {
       onKeyPress: this.handleMenuKeyPress,
       onMouseEnter: this.handleMenuMouseEnter,
       onMouseDown: this.handleMenuMouseDown,
+      onMouseUp: this.handleMenuMouseUp,
       onClick: this.handleMenuClick,
       onDoubleClick: this.handleMenuDoubleClick,
     };

--- a/packages/rewire-ui/src/components/colorPickerDialog.css
+++ b/packages/rewire-ui/src/components/colorPickerDialog.css
@@ -1,0 +1,7 @@
+/*
+  Necessary css styling because React-Color does not provide a proper way to get at all of the inner component styles.
+*/
+
+.sketch-picker span, .sketch-picker input {
+    font-size: 13px !important;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,9 +216,9 @@
     "@babel/types" "^7.2.0"
 
 "@babel/helpers@^7.2.0", "@babel/helpers@^7.4.0":
-  version "7.4.0"
-  resolved "https://npm.worksight.services/@babel%2fhelpers/-/helpers-7.4.0.tgz#03392e52c4ce7ad2e7b1cc07d1aba867a8ce2e32"
-  integrity sha512-2Lfcn74A2WSFUbYJ76ilYE1GnegCKUHTfXxp25EL2zPZHjV7OcDncqNjl295mUH0VnB65mNriXW4J5ROvxsgGg==
+  version "7.4.2"
+  resolved "https://npm.worksight.services/@babel%2fhelpers/-/helpers-7.4.2.tgz#3bdfa46a552ca77ef5a0f8551be5f0845ae989be"
+  integrity sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==
   dependencies:
     "@babel/template" "^7.4.0"
     "@babel/traverse" "^7.4.0"
@@ -234,9 +234,9 @@
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.3.4", "@babel/parser@^7.4.0":
-  version "7.4.0"
-  resolved "https://npm.worksight.services/@babel%2fparser/-/parser-7.4.0.tgz#6de669e73ac3a32c754280d0fef8fca6aad2c416"
-  integrity sha512-ZmMhJfU/+SXXvy9ALjDZopa3T3EixQtQai89JRC48eM9OUwrxJjYjuM/0wmdl2AekytlzMVhPY8cYdLb13kpKQ==
+  version "7.4.2"
+  resolved "https://npm.worksight.services/@babel%2fparser/-/parser-7.4.2.tgz#b4521a400cb5a871eab3890787b4bc1326d38d91"
+  integrity sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==
 
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
@@ -446,10 +446,10 @@
     "@babel/helper-module-transforms" "^7.1.0"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-named-capturing-groups-regex@^7.3.0":
-  version "7.3.0"
-  resolved "https://npm.worksight.services/@babel%2fplugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.3.0.tgz#140b52985b2d6ef0cb092ef3b29502b990f9cd50"
-  integrity sha512-NxIoNVhk9ZxS+9lSoAQ/LM0V2UEvARLttEHUrRDGKFaAxOYQcrkN/nLRE+BbbicCAvZPl7wMP0X60HsHE5DtQw==
+"@babel/plugin-transform-named-capturing-groups-regex@^7.4.2":
+  version "7.4.2"
+  resolved "https://npm.worksight.services/@babel%2fplugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.2.tgz#800391136d6cbcc80728dbdba3c1c6e46f86c12e"
+  integrity sha512-NsAuliSwkL3WO2dzWTOL1oZJHm0TM8ZY8ZSxk2ANyKkt5SQlToGA4pzctmq1BEjoacurdwZ3xp2dCQWJkME0gQ==
   dependencies:
     regexp-tree "^0.1.0"
 
@@ -531,9 +531,9 @@
     regexpu-core "^4.1.3"
 
 "@babel/preset-env@^7.4.1":
-  version "7.4.1"
-  resolved "https://npm.worksight.services/@babel%2fpreset-env/-/preset-env-7.4.1.tgz#80e19ad76f62fb136d57ee4b963db3e8a6840bad"
-  integrity sha512-uC2DeVb6ljdjBGhJCyHxNZfSJEVgPdUm2R5cX85GCl1Qreo5sMM5g85ntqtzRF7XRYGgnRmV5we9cdlvo1wJvg==
+  version "7.4.2"
+  resolved "https://npm.worksight.services/@babel%2fpreset-env/-/preset-env-7.4.2.tgz#2f5ba1de2daefa9dcca653848f96c7ce2e406676"
+  integrity sha512-OEz6VOZaI9LW08CWVS3d9g/0jZA6YCn1gsKIy/fut7yZCJti5Lm1/Hi+uo/U+ODm7g4I6gULrCP+/+laT8xAsA==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -563,7 +563,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.4.0"
     "@babel/plugin-transform-modules-systemjs" "^7.4.0"
     "@babel/plugin-transform-modules-umd" "^7.2.0"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.3.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.4.2"
     "@babel/plugin-transform-new-target" "^7.4.0"
     "@babel/plugin-transform-object-super" "^7.2.0"
     "@babel/plugin-transform-parameters" "^7.4.0"
@@ -582,17 +582,17 @@
     semver "^5.3.0"
 
 "@babel/runtime-corejs2@^7.3.4":
-  version "7.4.0"
-  resolved "https://npm.worksight.services/@babel%2fruntime-corejs2/-/runtime-corejs2-7.4.0.tgz#72e94a5b59300482c2a334c06958021057c30da8"
-  integrity sha512-54PQxRRKLRYTrF89Z9tyjJ+uoxyn05Avt1Ou6UT1x5QWpdo1FPQ15i/lGL+ZLvE5yxzlTO7u2oE06VCU9IYijA==
+  version "7.4.2"
+  resolved "https://npm.worksight.services/@babel%2fruntime-corejs2/-/runtime-corejs2-7.4.2.tgz#a0cec2c41717fa415e9c204f32b603d88b1796c2"
+  integrity sha512-y/Br/9uQnumcqcakkmobFqOTzYCWSS6Kuy1b2o7LTXR4lpeU0AhaOcPqIHW85LCxRWUDW5Vg0pU1KlE3YkORlg==
   dependencies:
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
 
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0":
-  version "7.4.0"
-  resolved "https://npm.worksight.services/@babel%2fruntime/-/runtime-7.4.0.tgz#d523416573f19aa12784639e631257c7fc58c0aa"
-  integrity sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==
+  version "7.4.2"
+  resolved "https://npm.worksight.services/@babel%2fruntime/-/runtime-7.4.2.tgz#f5ab6897320f16decd855eed70b705908a313fe8"
+  integrity sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -1531,9 +1531,9 @@
   integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
 
 "@types/node@*", "@types/node@^11.11.3":
-  version "11.11.4"
-  resolved "https://npm.worksight.services/@types%2fnode/-/node-11.11.4.tgz#8808bd5a82bbf6f5d412eff1c228d178e7c24bb3"
-  integrity sha512-02tIL+QIi/RW4E5xILdoAMjeJ9kYq5t5S2vciUdFPXv/ikFTb0zK8q9vXkg4+WAJuYXGiVT1H28AkD2C+IkXVw==
+  version "11.11.5"
+  resolved "https://npm.worksight.services/@types%2fnode/-/node-11.11.5.tgz#0c57e12eb44d44e5b6735593925286553ee7cebf"
+  integrity sha512-pz6wNe/XwyesgfVX7P6B0hY3TnTAYXk6KSTLdpQfbuq3be+hnMoCuFzE+yLTskPdBwmNiGRL2TAsnF09aRugvQ==
 
 "@types/prop-types@*":
   version "15.7.0"
@@ -3439,9 +3439,9 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.3.116, electron-to-chromium@^1.3.47:
-  version "1.3.117"
-  resolved "https://npm.worksight.services/electron-to-chromium/-/electron-to-chromium-1.3.117.tgz#4155184de82a284b8a598eab8e37b5875280c363"
-  integrity sha512-BxNTJ9Zu+WW5hbBg0fnjGfS1X8AOfJEtBmYlVDenPmkmkXmt3WgbPw7y/47mAZomcVB4F2/NZQB/KNz7OdCC2g==
+  version "1.3.118"
+  resolved "https://npm.worksight.services/electron-to-chromium/-/electron-to-chromium-1.3.118.tgz#5c82b0445a40934e6cae9c2f40bfaaa986ea44a3"
+  integrity sha512-/1FpHvmKmKo2Z6CCza2HfkrKvKhU7Rq4nvyX1FOherdTrdTufhVrJbCrcrIqgqUCI+BG6JC2rlY4z5QA1G0NOw==
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -7635,9 +7635,9 @@ uglify-es@^3.3.9:
     source-map "~0.6.1"
 
 uglify-js@^3.1.4:
-  version "3.5.0"
-  resolved "https://npm.worksight.services/uglify-js/-/uglify-js-3.5.0.tgz#72cd24773c4961023f4f292ab9531177a0021897"
-  integrity sha512-kY2sHdru6BcIDg+i1SCZ1bpPhZJ6yiE0bEKLEJDC4M/lDSMhr/zVJeuEzvHJGjAXJCizSzUVh9atREf2jnR7yQ==
+  version "3.5.1"
+  resolved "https://npm.worksight.services/uglify-js/-/uglify-js-3.5.1.tgz#29cb91e76c9941899bc74b075ad0e6da9250abd5"
+  integrity sha512-kI+3c+KphOAKIikQsZoT2oDsVYH5qvhpTtFObfMCdhPAYnjSvmW4oTWMhvDD4jtAGHJwztlBXQgozGcq3Xw9oQ==
   dependencies:
     commander "~2.19.0"
     source-map "~0.6.1"


### PR DESCRIPTION
…d select cells buttons again.

Rewire-grid:
    -Cell Selection refactored somewhat in order to improve the new selection clearing functionality when clicks outside of the currently selected grid are made (including other grids). No longer requires any monkeying around with passing onClick events to grids on pages where there are multiple grids. Also, drag selection starting from header or group row cells will properly function with the multi-select feature.

Rewire-ui:
    - Select and AutoComplete now block MouseUp handlers inside the menu when it is open. This is necessary for them to function properly within a grid cell with the refactoring of grid selection and selection clearing on external clicks.
    - increase the font size of the color picker inputs. Done via a hacky css way because that's the only way to do so with the current version of the color-picker package.