### PR TITLE
Rewire-grid: - Grid issues with height and scrolling overflow across …

### DIFF
--- a/examples/src/HomeView.tsx
+++ b/examples/src/HomeView.tsx
@@ -7,7 +7,7 @@ import { hotkeysModel, HotKeysDialog }           from './HotKeys';
 import { YesNoModel, YesNoDialog }               from './YesNoDialog';
 import { ConfirmationModel, ConfirmationDialog } from './YesNoDialog';
 import { Observe, observable }                   from 'rewire-core';
-import { ActionFn }                              from 'rewire-ui';
+import { ActionFn, WithStyle, withStyles}        from 'rewire-ui';
 import {
   createGrid,
   createColumn,
@@ -379,60 +379,113 @@ const yesAction: ActionFn = () => {
 const yesNoModel        = new YesNoModel({ title: 'Confirmation Required', action: yesAction });
 const confirmationModel = new ConfirmationModel({ title: 'Secondary Confirmation', yesAction: confirmationYesAction, noAction: confirmationNoAction});
 
-export const HomeView = (props: any) => <Observe render={() => (
-  <TransitionWrapper>
-  <div>
-    <Button color='primary' variant='contained' style={{marginRight: '15px'}} onClick={() => sampleModel.open()}>Load Dialog Test</Button>
-    <Button color='primary' variant='contained' style={{marginRight: '15px'}} onClick={() => hotkeysModel.open()}>Load Grid Hotkeys List</Button>
-    <Button color='primary' variant='contained'                               onClick={() => yesNoModel.open()}>Load Confirmation Dialog</Button>
+const styles = () => ({
+  openDialogButton: {
+    marginRight: '15px',
+  },
+  gridsSection: {
+    overflow: 'auto',
+    padding: '10px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: '10px',
+  },
+  gridActionButtonsContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  gridActionButton: {
+    margin: '0px 15px 10px 0px',
+  },
+  gridContainer: {
+    padding: '20px',
+    width: '80%',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: '20px',
+  },
+  employeesGridButtonsContainer: {
+    display: 'flex',
+    marginBottom: '10px',
+  },
+  employeesGridButton: {
+    marginRight: '10px',
+  },
+  dataGrid: {
+    height: '650px',
+  },
+  employeeGrid: {
+    height: '400px',
+  },
+});
 
-    <SampleDialog />
-    <HotKeysDialog />
+type HomeViewProps = WithStyle<ReturnType<typeof styles>>;
 
-    <ConfirmationDialog viewModel={confirmationModel} />
-    <YesNoDialog viewModel={yesNoModel}>
-      <Typography variant='h5'>Do you wish to delete your entire hard drive?</Typography>
-      <Typography variant='h6'>Please think before you answer</Typography>
-    </YesNoDialog>
+export const HomeView = withStyles(styles, (props: HomeViewProps) => {
+  const {classes} = props;
 
-    <div style={{overflow: 'auto', padding: 10, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center'}}>
-      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
-        <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => grid.selectCellByPos(0, 4)}>Select Cell</Button>
-        <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => grid.selectCellsByRange(1, 4, 3, 5)}>Select Cells</Button>
-        <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => {
-          grid.addRow({id: 'newRow-' + Math.random() * 2000, data: {column2: 'RC 2-1', column3: 'RC 3-1'}});
-          employeesGrid1.addRow({id: 'newRow-' + Math.random() * 2000, data: {name: 'New Employee', email: 'employeeEmail@test.com'}});
-        }}>
-          Add Row
-        </Button>
-        <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => grid.removeRow(grid.dataRowsByPosition[grid.dataRowsByPosition.length - 1].id)}>Remove Row</Button>
-        <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => grid.dataRowsByPosition.forEach(row => row.cells['numberColumn'].setValue(1337))}>Change Number Cell Value</Button>
-        <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => grid.dataRowsByPosition.forEach(row => row.setValue({'numberColumn': 2222, 'dateColumn': '1985-11-26'}))}>Change Number And Date Cells</Button>
-        <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => grid.dataRowsByPosition.forEach(row => row.clear(['numberColumn', 'dateColumn']))}>Clear Number And Date</Button>
-        <Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => grid.dataRowsByPosition.forEach(row => row.cells['complexColumn'].setValue(new ComplexCellData('smithers027', 'Smithers', 57)))}>
-          Change Complex Cell Value
-        </Button>
-      </div>
-      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
-        <Observe render={() => (<Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => { grid.column('column1')!.visible = !grid.column('column1')!.visible; }}> Toggle Column</Button>)} />
-        <Observe render={() => (<Button style={{margin: '0px 15px 10px 0px'}} variant='contained' disabled={!grid.changed} onClick={() => grid.revert()}>Enabled if has Changes. Reverts Changes</Button>)} />
-        <Observe render={() => (<Button style={{margin: '0px 15px 10px 0px'}} variant='contained' disabled={!grid.inError}>Enabled if has Errors</Button>)} />
-        <Observe render={() => (<Button style={{margin: '0px 15px 10px 0px'}} variant='contained' onClick={() => console.log(grid.get())}> Save All</Button>)} />
-        <Observe render={() => (<Button style={{margin: '0px 0px 10px 0px'}}  variant='contained' onClick={() => console.log(grid.getChanges())}> Save Changes</Button>)} />
-      </div>
+  return (
+    <Observe render={() => (
+      <TransitionWrapper>
+      <div>
+        <Button className={classes.openDialogButton} color='primary' variant='contained' onClick={() => sampleModel.open()}>Load Dialog Test</Button>
+        <Button className={classes.openDialogButton} color='primary' variant='contained' onClick={() => hotkeysModel.open()}>Load Grid Hotkeys List</Button>
+        <Button className={classes.openDialogButton} color='primary' variant='contained' onClick={() => yesNoModel.open()}>Load Confirmation Dialog</Button>
 
-      <Paper style={{padding: 20, width: '80%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', marginBottom: '20px'}}>
-        <Observe render={() => (<Grid grid={grid} gridFontSizes={{header: '0.9rem', body: '0.85rem', groupRow: '0.8rem'}} style={{height: '650px'}} />)} />
-      </Paper>
+        <SampleDialog />
+        <HotKeysDialog />
 
-      <Paper style={{padding: 20, width: '80%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center'}}>
-        <div style={{display: 'flex', marginBottom: '10px'}}>
-          <Button onClick={() => mode.gridMode = 'employees1'} style={{marginRight: '10px'}} variant='outlined'>Grid 1</Button>
-          <Button onClick={() => mode.gridMode = 'employees2'}                               variant='outlined'>Grid 2</Button>
+        <ConfirmationDialog viewModel={confirmationModel} />
+        <YesNoDialog viewModel={yesNoModel}>
+          <Typography variant='h5'>Do you wish to delete your entire hard drive?</Typography>
+          <Typography variant='h6'>Please think before you answer</Typography>
+        </YesNoDialog>
+
+        <div className={classes.gridsSection}>
+          <div className={classes.gridActionButtonsContainer}>
+            <Button className={classes.gridActionButton} variant='contained' onClick={() => grid.selectCellByPos(0, 4)}>Select Cell</Button>
+            <Button className={classes.gridActionButton} variant='contained' onClick={() => grid.selectCellsByRange(1, 4, 3, 5)}>Select Cells</Button>
+            <Button className={classes.gridActionButton} variant='contained' onClick={() => {
+              grid.addRow({id: 'newRow-' + Math.random() * 2000, data: {column2: 'RC 2-1', column3: 'RC 3-1'}});
+              employeesGrid1.addRow({id: 'newRow-' + Math.random() * 2000, data: {name: 'New Employee', email: 'employeeEmail@test.com'}});
+            }}>
+              Add Row
+            </Button>
+            <Button className={classes.gridActionButton} variant='contained' onClick={() => grid.removeRow(grid.dataRowsByPosition[grid.dataRowsByPosition.length - 1].id)}>Remove Row</Button>
+            <Button className={classes.gridActionButton} variant='contained' onClick={() => grid.dataRowsByPosition.forEach(row => row.cells['numberColumn'].setValue(1337))}>Change Number Cell Value</Button>
+            <Button className={classes.gridActionButton} variant='contained' onClick={() => grid.dataRowsByPosition.forEach(row => row.setValue({'numberColumn': 2222, 'dateColumn': '1985-11-26'}))}>Change Number And Date Cells</Button>
+            <Button className={classes.gridActionButton} variant='contained' onClick={() => grid.dataRowsByPosition.forEach(row => row.clear(['numberColumn', 'dateColumn']))}>Clear Number And Date</Button>
+            <Button className={classes.gridActionButton} variant='contained' onClick={() => grid.dataRowsByPosition.forEach(row => row.cells['complexColumn'].setValue(new ComplexCellData('smithers027', 'Smithers', 57)))}>
+              Change Complex Cell Value
+            </Button>
+          </div>
+          <div className={classes.gridActionButtonsContainer}>
+            <Observe render={() => (<Button className={classes.gridActionButton} variant='contained' onClick={() => { grid.column('column1')!.visible = !grid.column('column1')!.visible; }}> Toggle Column</Button>)} />
+            <Observe render={() => (<Button className={classes.gridActionButton} variant='contained' disabled={!grid.changed} onClick={() => grid.revert()}>Enabled if has Changes. Reverts Changes</Button>)} />
+            <Observe render={() => (<Button className={classes.gridActionButton} variant='contained' disabled={!grid.inError}>Enabled if has Errors</Button>)} />
+            <Observe render={() => (<Button className={classes.gridActionButton} variant='contained' onClick={() => console.log(grid.get())}> Save All</Button>)} />
+            <Observe render={() => (<Button className={classes.gridActionButton} variant='contained' onClick={() => console.log(grid.getChanges())}> Save Changes</Button>)} />
+          </div>
+
+          <Paper className={classes.gridContainer}>
+            <Observe render={() => (<Grid grid={grid} gridFontSizes={{header: '0.9rem', body: '0.85rem', groupRow: '0.8rem'}} className={classes.dataGrid} />)} />
+          </Paper>
+
+          <Paper className={classes.gridContainer}>
+            <div className={classes.employeesGridButtonsContainer}>
+              <Button className={classes.employeesGridButton} onClick={() => mode.gridMode = 'employees1'} variant='outlined'>Grid 1</Button>
+              <Button className={classes.employeesGridButton} onClick={() => mode.gridMode = 'employees2'} variant='outlined'>Grid 2</Button>
+            </div>
+            <Grid key={mode.gridMode} grid={mode.gridMode === 'employees1' ? employeesGrid1 : employeesGrid2} gridFontSizes={{header: '0.95rem', body: '0.9rem', groupRow: '0.8rem'}} className={classes.employeeGrid} />
+          </Paper>
         </div>
-        <Grid key={mode.gridMode} grid={mode.gridMode === 'employees1' ? employeesGrid1 : employeesGrid2} gridFontSizes={{header: '0.95rem', body: '0.9rem', groupRow: '0.8rem'}} style={{height: '400px'}} />
-      </Paper>
-    </div>
-  </div>
-  </TransitionWrapper>
-)} />;
+      </div>
+      </TransitionWrapper>
+    )} />
+  );
+});

--- a/examples/src/HotKeys.tsx
+++ b/examples/src/HotKeys.tsx
@@ -1,6 +1,6 @@
-import * as React        from 'react';
-import { Modal, Dialog } from 'rewire-ui';
-import Typography        from '@material-ui/core/Typography';
+import * as React                               from 'react';
+import { Modal, Dialog, WithStyle, withStyles } from 'rewire-ui';
+import Typography                               from '@material-ui/core/Typography';
 
 class HotkeysModel extends Modal {
   constructor() {
@@ -15,103 +15,129 @@ const getGridDialogTitle = (dialog: Modal): JSX.Element => {
   return <div>Grid Hotkeys List</div>;
 };
 
-export const HotKeysDialog = () => (
-  <Dialog dialog={hotkeysModel} title={getGridDialogTitle} maxWidth='sm'>
-    <div style={{padding: '16px', maxHeight: '500px'}}>
-      <div style={{display: 'flex', flexDirection: 'column', justifyContent: 'flex-start', alignItems: 'flex-start', flexWrap: 'wrap'}}>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Ctrl + C:</Typography>
-          <Typography>Copy Selected Cell(s)</Typography>
+const styles = () => ({
+  dialogContentsContainer: {
+    padding: '16px',
+    maxHeight: '600px',
+  },
+  dialogContents: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    alignItems: 'flex-start',
+    flexWrap: 'wrap',
+  },
+  hotkeyContainer: {
+    display: 'flex',
+  },
+  hotkeyLabel: {
+    width: '125px',
+  },
+});
+
+type HotKeysDialogProps = WithStyle<ReturnType<typeof styles>>;
+
+export const HotKeysDialog = withStyles(styles, (props: HotKeysDialogProps) => {
+    const {classes} = props;
+
+    return (
+      <Dialog dialog={hotkeysModel} title={getGridDialogTitle} maxWidth='sm'>
+        <div className={classes.dialogContentsContainer}>
+          <div className={classes.dialogContents}>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Ctrl + C:</Typography>
+              <Typography>Copy Selected Cell(s)</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Ctrl + V:</Typography>
+              <Typography>Paste To Selected Cell(s)</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Ctrl + X:</Typography>
+              <Typography>Cut Selected Cell(s)</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Ctrl + R:</Typography>
+              <Typography>Revert Selected Cell(s)</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Ctrl + U:</Typography>
+              <Typography>Revert Selected Row(s)</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Ctrl + Insert:</Typography>
+              <Typography>Insert Row below selected row(s)</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Ctrl + D:</Typography>
+              <Typography>Duplicate selected row(s)</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Ctrl + Delete:</Typography>
+              <Typography>Delete selected row(s)</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Escape:</Typography>
+              <Typography>If editing, exit editing without changes. Otherwise, de-select cell(s)</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Enter:</Typography>
+              <Typography>If editing, exit editing with changes</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Delete:</Typography>
+              <Typography>If not editing, delete value of selected cell(s)</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Arrow Up:</Typography>
+              <Typography>Move up one cell</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Arrow Down:</Typography>
+              <Typography>Move down one cell</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Arrow Left:</Typography>
+              <Typography>Move left one cell. If end of line, attempt to wrap to line above</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Arrow Right:</Typography>
+              <Typography>Move right one cell. If end of line, attempt to wrap to line below</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Home:</Typography>
+              <Typography>Go to the first selectable cell of the row</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>End:</Typography>
+              <Typography>Go to the last selectable cell of the row</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Ctrl + Home:</Typography>
+              <Typography>Go to the first selectable cell of the grid</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Ctrl + End:</Typography>
+              <Typography>Go to the last selectable cell of the grid</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Ctrl + Click:</Typography>
+              <Typography>If Multiselect, append selection</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Ctrl + Drag:</Typography>
+              <Typography>If Multiselect, append dragged cells</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Shift + Click:</Typography>
+              <Typography>If Multiselect, append cells between start and clicked cell</Typography>
+            </div>
+            <div className={classes.hotkeyContainer}>
+              <Typography className={classes.hotkeyLabel}>Shift + Drag:</Typography>
+              <Typography>If Multiselect, append cells between start and dragged cells</Typography>
+            </div>
+          </div>
         </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Ctrl + V:</Typography>
-          <Typography>Paste To Selected Cell(s)</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Ctrl + X:</Typography>
-          <Typography>Cut Selected Cell(s)</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Ctrl + R:</Typography>
-          <Typography>Revert Selected Cell(s)</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Ctrl + U:</Typography>
-          <Typography>Revert Selected Row(s)</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Ctrl + Insert:</Typography>
-          <Typography>Insert Row below selected row(s)</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Ctrl + D:</Typography>
-          <Typography>Duplicate selected row(s)</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Ctrl + Delete:</Typography>
-          <Typography>Delete selected row(s)</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Escape:</Typography>
-          <Typography>If editing, exit editing without changes. Otherwise, de-select cell(s)</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Enter:</Typography>
-          <Typography>If editing, exit editing with changes</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Delete:</Typography>
-          <Typography>If not editing, delete value of selected cell(s)</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Arrow Up:</Typography>
-          <Typography>Move up one cell</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Arrow Down:</Typography>
-          <Typography>Move down one cell</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Arrow Left:</Typography>
-          <Typography>Move left one cell. If end of line, attempt to wrap to line above</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Arrow Right:</Typography>
-          <Typography>Move right one cell. If end of line, attempt to wrap to line below</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Home:</Typography>
-          <Typography>Go to the first selectable cell of the row</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>End:</Typography>
-          <Typography>Go to the last selectable cell of the row</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Ctrl + Home:</Typography>
-          <Typography>Go to the first selectable cell of the grid</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Ctrl + End:</Typography>
-          <Typography>Go to the last selectable cell of the grid</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Ctrl + Click:</Typography>
-          <Typography>If Multiselect, append selection</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Ctrl + Drag:</Typography>
-          <Typography>If Multiselect, append dragged cells</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Shift + Click:</Typography>
-          <Typography>If Multiselect, append cells between start and clicked cell</Typography>
-        </div>
-        <div style={{display: 'flex'}}>
-          <Typography style={{width: '125px'}}>Shift + Drag:</Typography>
-          <Typography>If Multiselect, append cells between start and dragged cells</Typography>
-        </div>
-      </div>
-    </div>
-  </ Dialog>
-);
+      </ Dialog>
+    );
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire",
-  "version": "1.0.11",
+  "version": "1.0.14",
   "description": "WorkSight .NEXT core",
   "main": "src/index.js",
   "private": true,

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.11",
+  "version": "1.0.14",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.11",
+  "version": "1.0.14",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.11",
+  "version": "1.0.14",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.11",
+  "version": "1.0.14",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-grid/src/components/Cell.tsx
+++ b/packages/rewire-grid/src/components/Cell.tsx
@@ -159,9 +159,14 @@ class Cell extends React.PureComponent<CellProps, {}> {
       return;
     }
 
+    this.grid.isMouseDown = true;
+
     if (!evt.shiftKey || !this.grid.startCell) {
       this.grid.startCell = this.cell;
     }
+
+    evt.preventDefault();
+    evt.stopPropagation();
   }
 
   handleMouseEnter = (evt: React.MouseEvent<any>) => {

--- a/packages/rewire-grid/src/components/Grid.tsx
+++ b/packages/rewire-grid/src/components/Grid.tsx
@@ -235,6 +235,11 @@ const styles = (theme: Theme) => {
   let cellContainerLineHeight = `${2 * Math.round(bodyFontSizeDigits)}px`;
 
   let styleObj = {
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+      width: '100%',
+    },
     leftLabels: {
       backgroundColor: theme.palette.leftLabelBackground.main,
       '& tr.alt': {
@@ -457,6 +462,10 @@ const GridInternal = withStyles(styles, class extends React.PureComponent<GridPr
   handleMouseDown = (evt: React.MouseEvent<any>) => {
     this.grid.isMouseDown = true;
 
+    if (!evt.shiftKey) {
+      this.grid.startCell = undefined;
+    }
+
     evt.preventDefault();
     evt.stopPropagation();
   }
@@ -642,12 +651,13 @@ const GridInternal = withStyles(styles, class extends React.PureComponent<GridPr
 
   render() {
     const {style, className, classes} = this.props;
-    const maxHeight = style && style.height !== undefined ? style.height : undefined;
 
     return (
-      <div className={classNames('ws-grid', className, classes.wsGrid)} style={{maxHeight: maxHeight, ...style}} onMouseDown={(this.grid.multiSelect || this.grid.clearSelectionOnBlur) ? this.handleMouseDown : undefined}>
-        {this.renderHeaders()}
-        {this.renderData()}
+      <div className={classNames(classes.root, className)} style={{...style}}>
+        <div className={classNames('ws-grid', classes.wsGrid)} onMouseDown={(this.grid.multiSelect || this.grid.clearSelectionOnBlur) ? this.handleMouseDown : undefined}>
+          {this.renderHeaders()}
+          {this.renderData()}
+        </div>
       </div>
     );
   }

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.11",
+  "version": "1.0.14",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-ui/src/components/Select.tsx
+++ b/packages/rewire-ui/src/components/Select.tsx
@@ -242,7 +242,6 @@ class SelectInternal<T> extends React.Component<SelectInternalProps<T>, any> {
         let values = this.state.suggestions.filter((v: any) => event.target.value && event.target.value.includes(this.map(v)));
         values = values.length <= 0 ? undefined : values;
         this.props.onSelectItem(values);
-        // this.props.onSelectItem(this.state.suggestions.filter((v: any) => event.target.value && event.target.value.includes(this.map(v))));
       } else {
         this.props.onSelectItem(this.state.suggestions.find((v: any) => event.target.value === this.map(v)));
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,9 +1531,9 @@
   integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
 
 "@types/node@*", "@types/node@^11.11.3":
-  version "11.11.5"
-  resolved "https://npm.worksight.services/@types%2fnode/-/node-11.11.5.tgz#0c57e12eb44d44e5b6735593925286553ee7cebf"
-  integrity sha512-pz6wNe/XwyesgfVX7P6B0hY3TnTAYXk6KSTLdpQfbuq3be+hnMoCuFzE+yLTskPdBwmNiGRL2TAsnF09aRugvQ==
+  version "11.11.6"
+  resolved "https://npm.worksight.services/@types%2fnode/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
+  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
 
 "@types/prop-types@*":
   version "15.7.0"
@@ -7169,14 +7169,14 @@ react-color@^2.17.0:
     tinycolor2 "^1.4.1"
 
 react-dom@^16.8.4:
-  version "16.8.4"
-  resolved "https://npm.worksight.services/react-dom/-/react-dom-16.8.4.tgz#1061a8e01a2b3b0c8160037441c3bf00a0e3bc48"
-  integrity sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==
+  version "16.8.5"
+  resolved "https://npm.worksight.services/react-dom/-/react-dom-16.8.5.tgz#b3e37d152b49e07faaa8de41fdf562be3463335e"
+  integrity sha512-VIEIvZLpFafsfu4kgmftP5L8j7P1f0YThfVTrANMhZUFMDOsA6e0kfR6wxw/8xxKs4NB59TZYbxNdPCDW34x4w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.4"
+    scheduler "^0.13.5"
 
 react-event-listener@^0.6.2:
   version "0.6.6"
@@ -7188,9 +7188,9 @@ react-event-listener@^0.6.2:
     warning "^4.0.1"
 
 react-is@^16.5.2, react-is@^16.6.0, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1:
-  version "16.8.4"
-  resolved "https://npm.worksight.services/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
-  integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
+  version "16.8.5"
+  resolved "https://npm.worksight.services/react-is/-/react-is-16.8.5.tgz#c54ac229dd66b5afe0de5acbe47647c3da692ff8"
+  integrity sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -7267,14 +7267,14 @@ react-transition-group@^2.2.1:
     react-lifecycles-compat "^3.0.4"
 
 react@^16.8.4:
-  version "16.8.4"
-  resolved "https://npm.worksight.services/react/-/react-16.8.4.tgz#fdf7bd9ae53f03a9c4cd1a371432c206be1c4768"
-  integrity sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==
+  version "16.8.5"
+  resolved "https://npm.worksight.services/react/-/react-16.8.5.tgz#49be3b655489d74504ad994016407e8a0445de66"
+  integrity sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.4"
+    scheduler "^0.13.5"
 
 reactcss@^1.2.0:
   version "1.2.3"
@@ -7740,10 +7740,10 @@ sax@^1.2.4, sax@~1.2.4:
   resolved "https://npm.worksight.services/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.13.4:
-  version "0.13.4"
-  resolved "https://npm.worksight.services/scheduler/-/scheduler-0.13.4.tgz#8fef05e7a3580c76c0364d2df5e550e4c9140298"
-  integrity sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==
+scheduler@^0.13.5:
+  version "0.13.5"
+  resolved "https://npm.worksight.services/scheduler/-/scheduler-0.13.5.tgz#b7226625167041298af3b98088a9dbbf6d7733a8"
+  integrity sha512-K98vjkQX9OIt/riLhp6F+XtDPtMQhqNcf045vsh+pcuvHq+PHy1xCrH3pq1P40m6yR46lpVvVhKdEOtnimuUJw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
…browsers should now be fixed, by giving them an outer container. Before, the fix was to contain the grid component itself in a container when using it, or to pass a height in the style prop into the grid (which in turn used that to give it max-height for firefox). You can now just give the grid a width / height (min or max too) via either className or inline styles, and it should work.

    - Minor fix to multiselect. Clicking and dragging from a group row or header onto a cell when there are already cells selected will no longer act like a shift append unless the shift key is held down. Now properly clears the selection and beings a new one with the first cell moved into.

General:
    - Refactoring of HomeView and HotKeys examples to use style injection instead of inline styling.
    - Version updates.