### PR TITLE
Rewire-ui: - AutoComplete and MultiSelectAutoComplete overhaul to giv…

### DIFF
--- a/examples/src/HomeView.tsx
+++ b/examples/src/HomeView.tsx
@@ -15,6 +15,7 @@ import {
   IActionMenuItem,
   ToggleMenu,
   IToggleMenuItem,
+  ISuggestionsContainerComponentProps,
 } from 'rewire-ui';
 import {
   createGrid,
@@ -302,18 +303,36 @@ function toggleMenuHandleItemClick(item: IToggleMenuItem) {
   }
 }
 
+const clickHandler = (props: ISuggestionsContainerComponentProps) => () => {
+  console.log('Add Item!');
+  props.downShift.closeMenu();
+};
+
+const suggestionsContainerHeader = (props: ISuggestionsContainerComponentProps) => (
+  <div>
+    <Typography variant='subtitle1'><strong>Items Title</strong></Typography>
+  </div>
+);
+
+const suggestionsContainerFooter = (props: ISuggestionsContainerComponentProps) => (
+  <div>
+    <Button variant='contained' size='small' onClick={clickHandler(props)}>Add Item</Button>
+  </div>
+);
+
 function createEmployeesGrid1() {
   let cols: IColumn[] = observable([]);
 
   // add header columns
-  cols.push(createColumn('name',                    'Employee',            {type: 'text', width: '120px'}));
-  cols.push(createColumn('email',                   'Email',               {type: 'text', width: '120px'}));
-  cols.push(createColumn('isActive',                'IsActive',            {type: 'checked', width: '75px'}));
-  cols.push(createColumn('timeColumn',              'Time',                {type: {type: 'time'}, width: '150px'}));
-  cols.push(createColumn('selectColumn',            'Select',              {type: {type: 'select', options: countries}, width: '150px'}));
-  cols.push(createColumn('multiselectColumn',       'Multiselect',         {type: {type: 'multiselect', options: countries}, width: '150px'}));
-  cols.push(createColumn('autoCompleteColumn',      'Auto Complete',       {type: {type: 'auto-complete', options: countries}, width: '150px'}));
-  cols.push(createColumn('multiAutoCompleteColumn', 'Multi Auto Complete', {type: {type: 'multiselectautocomplete', options: countries}, width: '250px'}));
+  cols.push(createColumn('name',                       'Employee',               {type: 'text', width: '120px'}));
+  cols.push(createColumn('email',                      'Email',                  {type: 'text', width: '120px'}));
+  cols.push(createColumn('isActive',                   'IsActive',               {type: 'checked', width: '75px'}));
+  cols.push(createColumn('timeColumn',                 'Time',                   {type: {type: 'time'}, width: '150px'}));
+  cols.push(createColumn('selectColumn',               'Select',                 {type: {type: 'select', options: countries}, width: '150px'}));
+  cols.push(createColumn('multiselectColumn',          'Multiselect',            {type: {type: 'multiselect', options: countries}, width: '150px'}));
+  cols.push(createColumn('autoCompleteColumn',         'Auto Complete',          {type: {type: 'auto-complete', options: countries}, width: '150px'}));
+  cols.push(createColumn('advancedAutoCompleteColumn', 'Advanced Auto Complete', {type: {type: 'auto-complete', options: {search: countries.search, map: countries.map, openOnFocus: true, suggestionsContainerHeader: suggestionsContainerHeader, suggestionsContainerFooter: suggestionsContainerFooter}}, width: '150px'}));
+  cols.push(createColumn('multiAutoCompleteColumn',    'Multi Auto Complete',    {type: {type: 'multiselectautocomplete', options: countries}, width: '250px'}));
 
   // add employee rows
   let rows: IRowData[] = [];
@@ -328,6 +347,8 @@ function createEmployeesGrid1() {
         v = [{id: '14', name: 'Austria'}, {id: '21', name: 'Belgium'}];
       } else if (fieldName === 'multiAutoCompleteColumn') {
         v = [{id: '18', name: 'Bangladesh'}, {id: '19', name: 'Barbados'}];
+      } else if (fieldName === 'advancedAutoCompleteColumn') {
+        v = {id: '21', name: 'Belgium'};
       } else {
         v = employees[row][fieldName];
       }

--- a/examples/src/SampleDialog.tsx
+++ b/examples/src/SampleDialog.tsx
@@ -6,11 +6,31 @@ import {
   Modal,
   isRequired,
   and,
-  isSameAsOther
+  isSameAsOther,
+  ISuggestionsContainerComponentProps
 }                    from 'rewire-ui';
 import { Observe }   from 'rewire-core';
 import { delay }     from 'rewire-common';
+import Typography    from '@material-ui/core/Typography';
+import Button        from '@material-ui/core/Button';
 import { countries } from './demo-data';
+
+const clickHandler = (props: ISuggestionsContainerComponentProps) => () => {
+  console.log('Add Item!');
+  props.downShift.closeMenu();
+};
+
+const suggestionsContainerHeader = (props: ISuggestionsContainerComponentProps) => (
+  <div>
+    <Typography variant='subtitle1'><strong>Items Title</strong></Typography>
+  </div>
+);
+
+const suggestionsContainerFooter = (props: ISuggestionsContainerComponentProps) => (
+  <div>
+    <Button variant='contained' size='small' onClick={clickHandler(props)}>Add Item</Button>
+  </div>
+);
 
 export class SampleModel extends Modal {
   form: Form = Form.create(
@@ -30,6 +50,7 @@ export class SampleModel extends Modal {
       phone:                   Form.phone().label('Phone'),
       mask:                    Form.mask({mask: ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}).label('MyMask').validators(isRequired),
       trigger:                 Form.string().label('Trigger').placeholder('Change me to trigger handler').onValueChange((form: Form, v: any) => {form.setFieldValue('email', 'Triggered!@hotmail.com'); form.setFieldValue('money', 1337); }),
+      advancedAutoComplete:    Form.reference(countries, { suggestionsContainerHeader: suggestionsContainerHeader, suggestionsContainerFooter: suggestionsContainerFooter, openOnFocus: true }).label('Advanced AutoComplete').validators(isRequired).placeholder('select a country'),
     }, {
       email:                 'my_email@gmail.com',
       country:               {id: 2, name: 'Albania'},
@@ -41,7 +62,8 @@ export class SampleModel extends Modal {
       date:                  '2018-03-05',
       multi:                 `this is line 1\r\nthis is line 2\r\nand this is line 3`,
       color:                 '#ffeedd',
-      multiselectAutoComplete: [{ id: '0', name: 'Afghanistan' }, { id: '23', name: 'Benin' }, { id: '24', name: 'Bermuda' }]
+      multiselectAutoComplete: [{ id: '0', name: 'Afghanistan' }, { id: '23', name: 'Benin' }, { id: '24', name: 'Bermuda' }],
+      advancedAutoComplete: {id: 0, name: 'Afghanistan'},
     }
   );
 
@@ -68,7 +90,7 @@ const SampleFormView = React.memo(({ form }: { form: typeof sampleModel.form }) 
           <form.field.email.Editor />
           <form.field.country.Editor />
           <form.field.selectCountry.Editor />
-          <form.field.multiselectCountry.Editor />
+          <form.field.multiselectCountry.Editor className='span2' />
         </div>
         <div className='content'>
           <form.field.password.Editor />
@@ -83,6 +105,9 @@ const SampleFormView = React.memo(({ form }: { form: typeof sampleModel.form }) 
           <form.field.multi.Editor />
           <form.field.trigger.Editor />
           <form.field.color.Editor />
+        </div>
+        <div className='content'>
+          <form.field.advancedAutoComplete.Editor />
         </div>
         <div className='content'>
           <form.field.multiselectAutoComplete.Editor />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "WorkSight .NEXT core",
   "main": "src/index.js",
   "private": true,

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-grid/src/models/GridTypes.ts
+++ b/packages/rewire-grid/src/models/GridTypes.ts
@@ -4,6 +4,7 @@ import {
   SearchFn,
   MapFn,
   IToggleMenuItem,
+  ISuggestionsContainerComponent,
 } from 'rewire-ui';
 import { IValidateFnData } from './Validator';
 import * as merge          from 'deepmerge';
@@ -280,13 +281,13 @@ export type MaskType = (string | RegExp)[];
 export type IColumnEditor =
   'text' | 'date' | 'checked' | 'none' |
   {type: 'time', options?: {rounding?: number}} |
-  {type: 'auto-complete', options: {search: SearchFn<any>, map: MapFn<any>}} |
-  {type: 'multiselectautocomplete', options: {search: SearchFn<any>, map: MapFn<any>}} |
   {type: 'select', options: {search: SearchFn<any>, map: MapFn<any>}} |
   {type: 'multiselect', options: {search: SearchFn<any>, map: MapFn<any>}} |
   {type: 'number', options?: {decimals?: number, thousandSeparator?: boolean, fixed?: boolean, allowNegative?: boolean}} |
   {type: 'phone', options?: {format?: string, mask?: string}} |
-  {type: 'mask', options?: {mask?: MaskType | (() => MaskType), guide?: boolean, placeholderChar?: string, showMask?: boolean}};
+  {type: 'mask', options?: {mask?: MaskType | (() => MaskType), guide?: boolean, placeholderChar?: string, showMask?: boolean}} |
+  {type: 'auto-complete', options: {search: SearchFn<any>, map: MapFn<any>, openOnFocus?: boolean, showEmptySuggestions?: boolean, suggestionsContainerHeader?: ISuggestionsContainerComponent, suggestionsContainerFooter?: ISuggestionsContainerComponent}} |
+  {type: 'multiselectautocomplete', options: {search: SearchFn<any>, map: MapFn<any>, openOnFocus?: boolean, showEmptySuggestions?: boolean, suggestionsContainerHeader?: ISuggestionsContainerComponent, suggestionsContainerFooter?: ISuggestionsContainerComponent}};
 
 export interface ICellProperties {
   id        : number;

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-ui/src/components/AutoComplete.tsx
+++ b/packages/rewire-ui/src/components/AutoComplete.tsx
@@ -1,13 +1,16 @@
 import * as React              from 'react';
 import * as is                 from 'is';
+import classNames              from 'classnames';
 import Downshift, {
   ControllerStateAndHelpers,
   StateChangeOptions }         from 'downshift';
 import TextField               from '@material-ui/core/TextField';
+import Fade                    from '@material-ui/core/Fade';
 import Paper                   from '@material-ui/core/Paper';
 import Popper                  from '@material-ui/core/Popper';
 import MenuItem                from '@material-ui/core/MenuItem';
 import InputAdornment          from '@material-ui/core/InputAdornment';
+import Typography              from '@material-ui/core/Typography';
 import {Theme}                 from '@material-ui/core/styles';
 import {debounce, match}       from 'rewire-common';
 import {withStyles, WithStyle} from './styles';
@@ -24,11 +27,26 @@ const styles = (theme: Theme) => ({
     position: 'relative',
   },
   popper: {
-    minWidth: '225px',
+    zIndex: 1300,
+  },
+  suggestionsPaper: {
+  },
+  suggestionsPaperContained: {
+    padding: '15px',
+  },
+  suggestions: {
     overflowY: 'auto',
     maxHeight: 'calc(50vh - 20px)',
-    boxShadow: theme.shadows[7],
-    zIndex: 1300,
+  },
+  suggestionsContained: {
+    maxHeight: 'calc(50vh - 150px)',
+    border: `1px solid ${theme.palette.common.black}`,
+  },
+  suggestionsHasHeader: {
+    marginTop: '15px',
+  },
+  suggestionsHasFooter: {
+    marginBottom: '15px',
   },
   textField: {
     width: '100%',
@@ -74,6 +92,9 @@ const styles = (theme: Theme) => ({
     height: 'auto',
     lineHeight: '1em',
   },
+  noResults: {
+    padding: '11px 16px',
+  },
   helperTextRoot: {
     marginTop: '6px',
     fontSize: '0.8em',
@@ -84,11 +105,25 @@ const styles = (theme: Theme) => ({
   },
 });
 
-interface IAutoCompleteProps {
-  selectOnFocus?   : boolean;
-  endOfTextOnFocus?: boolean;
+
+export interface ISuggestionsContainerComponentProps {
+  downShift: any;
+}
+
+export type ISuggestionsContainerComponent = (props?: ISuggestionsContainerComponentProps) => JSX.Element;
+
+export interface IAutoCompleteProps {
+  selectOnFocus?        : boolean;
+  endOfTextOnFocus?     : boolean;
   cursorPositionOnFocus?: number;
-  initialInputValue?: any;
+  initialInputValue?    : any;
+  openOnFocus?          : boolean;
+  showEmptySuggestions? : boolean;
+  hasTransition?        : boolean;
+  transitionTimeout?    : number;
+
+  suggestionsContainerHeader?: ISuggestionsContainerComponent;
+  suggestionsContainerFooter?: ISuggestionsContainerComponent;
 }
 
 export type AutoCompleteProps<T> = WithStyle<ReturnType<typeof styles>, IAutoCompleteProps & ICustomProps<T> & React.InputHTMLAttributes<any>>;
@@ -185,13 +220,13 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
   }
 
   renderSuggestion = (params: any) => {
-    const { suggestion, index, itemProps, theme, highlightedIndex, inputValue, classes, fontSize } = params;
+    const { suggestion, index, itemProps, theme, highlightedIndex, inputValue, classes } = params;
     const isHighlighted = highlightedIndex === index;
     const name          = this.map(suggestion);
 
     if (this.props.renderSuggestion) {
       return (
-        <MenuItem selected={isHighlighted} component='div' key={index} className={classes.menuItem} style={{fontSize: fontSize}}>
+        <MenuItem selected={isHighlighted} component='div' key={index} className={classes.menuItem}>
           {this.props.renderSuggestion(suggestion, {theme, isHighlighted, inputValue})}
         </MenuItem>
       );
@@ -206,7 +241,6 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
         selected={isHighlighted}
         component='div'
         className={classes.menuItem}
-        style={{fontSize: fontSize}}
       >{parts.map((part, index) => {
           return part.highlight ? (
             <span key={String(index)} style={{ fontWeight: 700 }} dangerouslySetInnerHTML={{__html: part.text}} />
@@ -218,8 +252,9 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
     );
   }
 
-  renderSuggestionsContainer = (options: any) => {
-    const { getMenuProps, isOpen, children, classes } = options;
+  renderSuggestionsContainerContents = (props: any) => {
+    const { suggestionsContainerHeader, suggestionsContainerFooter, suggestions, options } = props;
+    const { getMenuProps, isOpen, classes } = options;
     const menuProps = {
       onMouseDown: this.handleMenuMouseDown,
       onMouseUp: this.handleMenuMouseUp,
@@ -227,17 +262,74 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
       onDoubleClick: this.handleMenuDoubleClick,
     };
 
-    if (!children || children.length <= 0) {
-      return null;
+    let suggestionsPaperClasses: string[] = [classes.suggestionsPaper];
+    let suggestionsClasses: string[]      = [classes.suggestions];
+    if (suggestionsContainerHeader || suggestionsContainerFooter) {
+      suggestionsPaperClasses.push(classes.suggestionsPaperContained);
+      suggestionsClasses.push(classes.suggestionsContained);
+
+      if (suggestionsContainerHeader) {
+        suggestionsClasses.push(classes.suggestionsHasHeader);
+      }
+
+      if (suggestionsContainerFooter) {
+        suggestionsClasses.push(classes.suggestionsHasFooter);
+      }
     }
 
+    let fontSize = window.getComputedStyle(this.suggestionsContainerNode).getPropertyValue('font-size'); // needed to keep the suggestions the same font size as the input
+    let suggestionsContainerComponentProps: ISuggestionsContainerComponentProps = {
+      downShift: this.downShift,
+    };
+
     return (
-      <Popper open={isOpen} placement='bottom-start' anchorEl={this.suggestionsContainerNode} className={classes.popper} style={{width: this.suggestionsContainerNode ? this.suggestionsContainerNode.clientWidth : 'auto'}}>
-        <div {...(isOpen ? getMenuProps({}, {suppressRefError: true}) : {})} {...menuProps}>
-          <Paper>
-            {children}
-          </Paper>
-        </div>
+      <div {...(isOpen ? getMenuProps({}, {suppressRefError: true}) : {})} {...menuProps}>
+        <Paper elevation={4} className={classNames(...suggestionsPaperClasses)}>
+          {suggestionsContainerHeader && suggestionsContainerHeader(suggestionsContainerComponentProps)}
+          <div className={classNames(...suggestionsClasses)} style={{fontSize: fontSize}}>
+            {suggestions}
+          </div>
+          {suggestionsContainerFooter && suggestionsContainerFooter(suggestionsContainerComponentProps)}
+        </Paper>
+      </div>
+    );
+  }
+
+  renderSuggestionsContainer = (options: any) => {
+    const { openOnFocus, showEmptySuggestions, suggestionsContainerHeader, suggestionsContainerFooter, hasTransition, transitionTimeout } = this.props;
+    const { isOpen, children, classes } = options;
+
+    let transition  = hasTransition !== undefined ? hasTransition : true;
+    let timeout     = transitionTimeout !== undefined && transitionTimeout >= 0 ? transitionTimeout : 350;
+    let showEmpty   = showEmptySuggestions !== undefined ? showEmptySuggestions : openOnFocus ? true : false;
+    let suggestions = children;
+
+    if (!suggestions || suggestions.length <= 0) {
+      if (showEmpty) {
+       suggestions = <Typography className={classNames(classes.menuItem, classes.noResults)}>No Results</Typography>;
+      } else {
+        return null;
+      }
+    }
+
+    const popperModifiers = {
+      preventOverflow: {
+        boundariesElement: 'viewport',
+      },
+    };
+
+    return (
+      <Popper open={isOpen} placement='bottom-start' anchorEl={this.suggestionsContainerNode} transition={transition} modifiers={popperModifiers} className={classes.popper} style={{minWidth: this.suggestionsContainerNode ? this.suggestionsContainerNode.clientWidth : 'auto'}}>
+        {transition
+          ? ({ TransitionProps }) => (
+              <Fade {...TransitionProps} timeout={timeout}>
+                <div>
+                  <this.renderSuggestionsContainerContents suggestions={suggestions} suggestionsContainerHeader={suggestionsContainerHeader} suggestionsContainerFooter={suggestionsContainerFooter} options={...options} />
+                </div>
+              </Fade>
+            )
+          : <this.renderSuggestionsContainerContents suggestions={suggestions} suggestionsContainerHeader={suggestionsContainerHeader} suggestionsContainerFooter={suggestionsContainerFooter} options={...options} />
+        }
       </Popper>
     );
   }
@@ -250,6 +342,10 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
     } else if (this.props.cursorPositionOnFocus !== undefined) {
       let cursorPosition = Math.max(0, Math.min(this.props.cursorPositionOnFocus, evt.target.value.length));
       evt.target.setSelectionRange(cursorPosition, cursorPosition);
+    }
+
+    if (this.props.openOnFocus) {
+      setTimeout(() => this.downShift.openMenu(), 0);
     }
   }
 
@@ -341,7 +437,7 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
     }
   }
 
-  shouldComponentUpdate(nextProps: ICustomProps<T> & React.InputHTMLAttributes<any>, nextState: any, nextContext: any) {
+  shouldComponentUpdate(nextProps: IAutoCompleteProps & ICustomProps<T> & React.InputHTMLAttributes<any>, nextState: any, nextContext: any) {
     return (
         (nextProps.selectedItem !== this.props.selectedItem) ||
         (nextProps.error !== this.props.error) ||
@@ -354,7 +450,13 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
         (nextProps.variant !== this.props.variant) ||
         (nextProps.disableErrors !== this.props.disableErrors) ||
         (nextProps.startAdornment !== this.props.startAdornment) ||
-        (nextProps.endAdornment !== this.props.endAdornment)
+        (nextProps.endAdornment !== this.props.endAdornment) ||
+        (nextProps.suggestionsContainerHeader !== this.props.suggestionsContainerHeader) ||
+        (nextProps.suggestionsContainerFooter !== this.props.suggestionsContainerFooter) ||
+        (nextProps.openOnFocus !== this.props.openOnFocus) ||
+        (nextProps.showEmptySuggestions !== this.props.showEmptySuggestions) ||
+        (nextProps.hasTransition !== this.props.hasTransition) ||
+        (nextProps.transitionTimeout !== this.props.transitionTimeout)
       );
   }
 
@@ -415,7 +517,6 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
                     itemProps: getItemProps({ item: suggestion }),
                     highlightedIndex,
                     selectedItem,
-                    fontSize: window.getComputedStyle(this.suggestionsContainerNode).getPropertyValue('font-size') // needed to make the menu items font-size the same as the shown value,
                   }),
                 ),
               })}

--- a/packages/rewire-ui/src/components/TextField.tsx
+++ b/packages/rewire-ui/src/components/TextField.tsx
@@ -114,8 +114,16 @@ class TextFieldInternal extends React.Component<TextFieldPropsStyled> {
   }
 
   shouldComponentUpdate(nextProps: TextFieldPropsStyled) {
+    let equalValue: boolean;
+
+    if (nextProps.multiline && nextProps.value && this.props.value) {
+      equalValue = nextProps.value.localeCompare(this.props.value) === 0;
+    } else {
+      equalValue = nextProps.value === this.props.value;
+    }
+
     return (
-      (nextProps.value !== this.props.value) ||
+      !equalValue ||
       (nextProps.disabled !== this.props.disabled) ||
       (nextProps.visible !== this.props.visible) ||
       (nextProps.error !== this.props.error) ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -1392,9 +1392,9 @@
     universal-user-agent "^2.0.1"
 
 "@octokit/rest@^16.16.0":
-  version "16.23.4"
-  resolved "https://npm.worksight.services/@octokit%2frest/-/rest-16.23.4.tgz#4d8bcb1cc0cf6eeb8865632d4d60d79fc3425bbf"
-  integrity sha512-fQuYQ0vgNLkzeN0KEsqN0aS6EPzcuaePT5M5cE5qnKayaxFwRIQOMhNR/rTmEqo/zDK/20ZAcHsgLKodSsJtww==
+  version "16.24.1"
+  resolved "https://npm.worksight.services/@octokit%2frest/-/rest-16.24.1.tgz#883a4c144e9d8e4daa868d156d336fc67c5280b4"
+  integrity sha512-V2GVL+cfuwNTcZ9qtBMOR9pIftWo1AiZIiGvWNmTcIQG5mkj83ZXC+g3w5g0cVXt7Hi+mSOrD2bZ7HJOuouUNg==
   dependencies:
     "@octokit/request" "3.0.0"
     atob-lite "^2.0.0"
@@ -1584,9 +1584,9 @@
     "@types/react" "*"
 
 "@types/react-beautiful-dnd@^10.1.0":
-  version "10.1.1"
-  resolved "https://npm.worksight.services/@types%2freact-beautiful-dnd/-/react-beautiful-dnd-10.1.1.tgz#7afae39a4247f30c13b8bbb726ccd1b8cda9d4a5"
-  integrity sha512-75XELhEIWKTkyd1GdVZFvS1MtJwDs9tM37BbIat8mevcw+uH5dcJzZiwESHIWAzySHawS48nkKCQk/bEDp13Mw==
+  version "10.1.2"
+  resolved "https://npm.worksight.services/@types%2freact-beautiful-dnd/-/react-beautiful-dnd-10.1.2.tgz#74069f7b1d0cb67b7af99a2584b30e496e545d8b"
+  integrity sha512-76M5VRbhduUarM9wyMWQm3tLKCVMKTlhG0+W67dteg/HBE+kueIwuyLWzE0m5fmuilvrDXoM5NL890KLnHETZw==
   dependencies:
     "@types/react" "*"
 
@@ -1919,9 +1919,9 @@ assign-symbols@^1.0.0:
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
 async-each@^1.0.0, async-each@^1.0.1:
-  version "1.0.2"
-  resolved "https://npm.worksight.services/async-each/-/async-each-1.0.2.tgz#8b8a7ca2a658f927e9f307d6d1a42f4199f0f735"
-  integrity sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg==
+  version "1.0.3"
+  resolved "https://npm.worksight.services/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
+  integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
 async-limiter@~1.0.0:
   version "1.0.0"
@@ -2491,9 +2491,9 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
 bowser@^2.0.0-beta.3:
-  version "2.2.1"
-  resolved "https://npm.worksight.services/bowser/-/bowser-2.2.1.tgz#a3763878ba5a63703a9a2209cf87d7c2705f13e2"
-  integrity sha512-5juDN48U85WUgYctziMoE4KMZ0LhfJzKmTWgdCVrkZQsmQxlOpDhbS91JnXiNmyfQkgppbuF6Vv3z+fuxz86pQ==
+  version "2.3.0"
+  resolved "https://npm.worksight.services/bowser/-/bowser-2.3.0.tgz#624798388d972ec9639eb877629bca8ffd415c60"
+  integrity sha512-qaw3ZkREeT6HfHxr7HAY/xUdJHiopfktBUrctrlaLImZZYW82mLvHd04Fg3Zp/mnbt+YrMfX7PImZIL+65h7FQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -2547,13 +2547,13 @@ browserslist@^3.2.6:
     electron-to-chromium "^1.3.47"
 
 browserslist@^4.0.0, browserslist@^4.5.2, browserslist@^4.5.4:
-  version "4.5.4"
-  resolved "https://npm.worksight.services/browserslist/-/browserslist-4.5.4.tgz#166c4ecef3b51737a42436ea8002aeea466ea2c7"
-  integrity sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==
+  version "4.5.5"
+  resolved "https://npm.worksight.services/browserslist/-/browserslist-4.5.5.tgz#fe1a352330d2490d5735574c149a85bc18ef9b82"
+  integrity sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==
   dependencies:
-    caniuse-lite "^1.0.30000955"
-    electron-to-chromium "^1.3.122"
-    node-releases "^1.1.13"
+    caniuse-lite "^1.0.30000960"
+    electron-to-chromium "^1.3.124"
+    node-releases "^1.1.14"
 
 btoa-lite@^1.0.0:
   version "1.0.0"
@@ -2686,10 +2686,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000955:
-  version "1.0.30000957"
-  resolved "https://npm.worksight.services/caniuse-lite/-/caniuse-lite-1.0.30000957.tgz#fb1026bf184d7d62c685205358c3b24b9e29f7b3"
-  integrity sha512-8wxNrjAzyiHcLXN/iunskqQnJquQQ6VX8JHfW5kLgAPRSiSuKZiNfmIkP5j7jgyXqAQBSoXyJxfnbCFS0ThSiQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000960:
+  version "1.0.30000960"
+  resolved "https://npm.worksight.services/caniuse-lite/-/caniuse-lite-1.0.30000960.tgz#ec48297037e5607f582f246ae7b12bee66a78999"
+  integrity sha512-7nK5qs17icQaX6V3/RYrJkOsZyRNnroA4+ZwxaKJzIKy+crIy0Mz5CBlLySd2SNV+4nbUZeqeNfiaEieUBu3aA==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2960,9 +2960,9 @@ compare-func@^1.3.1:
     dot-prop "^3.0.0"
 
 component-emitter@^1.2.1:
-  version "1.2.1"
-  resolved "https://npm.worksight.services/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
-  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
+  version "1.3.0"
+  resolved "https://npm.worksight.services/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 compressible@~2.0.16:
   version "2.0.16"
@@ -3675,7 +3675,7 @@ ee-first@1.1.1:
   resolved "https://npm.worksight.services/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.122, electron-to-chromium@^1.3.47:
+electron-to-chromium@^1.3.124, electron-to-chromium@^1.3.47:
   version "1.3.124"
   resolved "https://npm.worksight.services/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz#861fc0148748a11b3e5ccebdf8b795ff513fa11f"
   integrity sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w==
@@ -4191,12 +4191,12 @@ fs.realpath@^1.0.0:
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.0.0, fsevents@^1.2.7:
-  version "1.2.7"
-  resolved "https://npm.worksight.services/fsevents/-/fsevents-1.2.7.tgz#4851b664a3783e52003b3c66eb0eee1074933aa4"
-  integrity sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==
+  version "1.2.8"
+  resolved "https://npm.worksight.services/fsevents/-/fsevents-1.2.8.tgz#57ea5320f762cd4696e5e8e87120eccc8b11cacf"
+  integrity sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==
   dependencies:
-    nan "^2.9.2"
-    node-pre-gyp "^0.10.0"
+    nan "^2.12.1"
+    node-pre-gyp "^0.12.0"
 
 fstream@^1.0.0, fstream@^1.0.2:
   version "1.0.11"
@@ -4473,9 +4473,9 @@ growl@1.10.5:
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
 handlebars@^4.1.0:
-  version "4.1.1"
-  resolved "https://npm.worksight.services/handlebars/-/handlebars-4.1.1.tgz#6e4e41c18ebe7719ae4d38e5aca3d32fa3dd23d3"
-  integrity sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==
+  version "4.1.2"
+  resolved "https://npm.worksight.services/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -4796,9 +4796,9 @@ inquirer@^3.0.6:
     through "^2.3.6"
 
 inquirer@^6.2.0:
-  version "6.2.2"
-  resolved "https://npm.worksight.services/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
-  integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
+  version "6.3.1"
+  resolved "https://npm.worksight.services/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
+  integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
   dependencies:
     ansi-escapes "^3.2.0"
     chalk "^2.4.2"
@@ -4811,7 +4811,7 @@ inquirer@^6.2.0:
     run-async "^2.2.0"
     rxjs "^6.4.0"
     string-width "^2.1.0"
-    strip-ansi "^5.0.0"
+    strip-ansi "^5.1.0"
     through "^2.3.6"
 
 invariant@^2.2.2, invariant@^2.2.4:
@@ -4831,10 +4831,10 @@ ip@^1.1.5:
   resolved "https://npm.worksight.services/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
-ipaddr.js@1.8.0:
-  version "1.8.0"
-  resolved "https://npm.worksight.services/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
-  integrity sha1-6qM9bd16zo9/b+DJygRA5wZzix4=
+ipaddr.js@1.9.0:
+  version "1.9.0"
+  resolved "https://npm.worksight.services/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
+  integrity sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -5216,7 +5216,7 @@ js-yaml@3.13.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.13.0:
+js-yaml@^3.13.0, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://npm.worksight.services/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -5945,7 +5945,7 @@ mute-stream@~0.0.4:
   resolved "https://npm.worksight.services/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.9.2:
+nan@^2.12.1:
   version "2.13.2"
   resolved "https://npm.worksight.services/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
@@ -6049,10 +6049,10 @@ node-gyp@^3.8.0:
     tar "^2.0.0"
     which "1"
 
-node-pre-gyp@^0.10.0:
-  version "0.10.3"
-  resolved "https://npm.worksight.services/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
-  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
+node-pre-gyp@^0.12.0:
+  version "0.12.0"
+  resolved "https://npm.worksight.services/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
+  integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -6065,10 +6065,10 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.13:
-  version "1.1.14"
-  resolved "https://npm.worksight.services/node-releases/-/node-releases-1.1.14.tgz#f1f41c83cac82caebd6739e6313d56b3b09c9189"
-  integrity sha512-d58EpVZRhQE60kWiWUaaPlK9dyC4zg3ZoMcHcky2d4hDksyQj0rUozwInOl0C66mBsqo01Tuns8AvxnL5S7PKg==
+node-releases@^1.1.14:
+  version "1.1.15"
+  resolved "https://npm.worksight.services/node-releases/-/node-releases-1.1.15.tgz#9e76a73b0eca3bf7801addaa0e6ce90c795f2b9a"
+  integrity sha512-cKV097BQaZr8LTSRUa2+oc/aX5L8UkZtPQrMSTgiJEeaW7ymTDCoRaGCoaTqk0lqnalcoSHu4wjSl0Cmj2+bMw==
   dependencies:
     semver "^5.3.0"
 
@@ -6544,9 +6544,9 @@ parse-url@^5.0.0:
     protocols "^1.4.0"
 
 parseurl@~1.3.2:
-  version "1.3.2"
-  resolved "https://npm.worksight.services/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
-  integrity sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=
+  version "1.3.3"
+  resolved "https://npm.worksight.services/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -7038,12 +7038,12 @@ protoduck@^5.0.1:
     genfun "^5.0.0"
 
 proxy-addr@~2.0.4:
-  version "2.0.4"
-  resolved "https://npm.worksight.services/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93"
-  integrity sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==
+  version "2.0.5"
+  resolved "https://npm.worksight.services/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"
+  integrity sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==
   dependencies:
     forwarded "~0.1.2"
-    ipaddr.js "1.8.0"
+    ipaddr.js "1.9.0"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -8161,7 +8161,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+strip-ansi@^5.1.0:
   version "5.2.0"
   resolved "https://npm.worksight.services/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -8263,9 +8263,9 @@ supports-color@^6.1.0:
     has-flag "^3.0.0"
 
 svgo@^1.0.0:
-  version "1.2.1"
-  resolved "https://npm.worksight.services/svgo/-/svgo-1.2.1.tgz#3fedde75a4016193e1c2608b5fdef6f3e4a9fd99"
-  integrity sha512-Y1+LyT4/y1ms4/0yxPMSlvx6dIbgklE9w8CIOnfeoFGB74MEkq8inSfEr6NhocTaFbyYp0a1dvNgRKGRmEBlzA==
+  version "1.2.2"
+  resolved "https://npm.worksight.services/svgo/-/svgo-1.2.2.tgz#0253d34eccf2aed4ad4f283e11ee75198f9d7316"
+  integrity sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==
   dependencies:
     chalk "^2.4.1"
     coa "^2.0.2"
@@ -8274,7 +8274,7 @@ svgo@^1.0.0:
     css-tree "1.0.0-alpha.28"
     css-url-regex "^1.1.0"
     csso "^3.5.1"
-    js-yaml "^3.13.0"
+    js-yaml "^3.13.1"
     mkdirp "~0.5.1"
     object.values "^1.1.0"
     sax "~1.2.4"


### PR DESCRIPTION
…e them more options and more stable positioning of its suggestions container relative to its input field. Now has options to give the suggestions container header and footer components, have it open the container on focus, show empty suggestions (No Results), and have a transition with customizable timeout.

    - Bug Fix for multiline TextFields (Form type of 'multistring'). The comparison in shouldComponentUpdate will now do a string localeCompare on the values instead of an equality test, which fixes the issue of an infinite re-render in Firefox.

Rewire-grid: - added all options above to the columns of type autocomplete and multiselectautocomplete to the grid (except for transition and transition timeout, as these will always use the defaults in the grid).

Examples: - added examples of autocompletes with some of the new options to SampleDialog and HomeView employee grid 1.