### PR TITLE
Rewire-ui: -Avatar Field Fix for the Change Image button being focuse…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "WorkSight .NEXT core",
   "main": "src/index.js",
   "private": true,

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-ui/src/components/AutoComplete.tsx
+++ b/packages/rewire-ui/src/components/AutoComplete.tsx
@@ -364,7 +364,7 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
     }
   }
 
-  handleKeyDown = (event: React.KeyboardEvent<any>) => {
+  handleKeyDown = (event: any) => {
     if (event.altKey || event.ctrlKey) {
       return;
     }
@@ -387,6 +387,14 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
           event.preventDefault();
           event.stopPropagation();
           event.nativeEvent.stopImmediatePropagation();
+        }
+        break;
+      case 27:
+        const st = this.downShift.getState();
+        if (st.isOpen) {
+          event.nativeEvent.preventDownshiftDefault = false;
+        } else {
+          event.nativeEvent.preventDownshiftDefault = true;
         }
         break;
       case 37:

--- a/packages/rewire-ui/src/components/AvatarCropper.tsx
+++ b/packages/rewire-ui/src/components/AvatarCropper.tsx
@@ -232,6 +232,25 @@ class AvatarCropper extends React.Component<AvatarCropperProps, IAvatarCropperSt
     this.onSaveCallback(this.getPreview());
   }
 
+  onKeyDown = (evt: React.KeyboardEvent<any>) => {
+    if (evt.altKey || evt.ctrlKey) {
+      return;
+    }
+
+    switch (evt.key) {
+      case 'Escape':
+        this.onCancelClick();
+        evt.stopPropagation();
+        evt.preventDefault();
+        break;
+      case 'Enter':
+        this.onSaveClick();
+        evt.stopPropagation();
+        evt.preventDefault();
+        break;
+    }
+  }
+
   getPreview() {
     const crop = this.state.crop;
 
@@ -504,7 +523,7 @@ class AvatarCropper extends React.Component<AvatarCropperProps, IAvatarCropperSt
 
     return (
       <div className={classes.root}>
-        <Dialog classes={{paper: classes.cropperDialogPaper}} open={true} disableBackdropClick={true} onEscapeKeyDown={this.onCancelClick}>
+        <Dialog classes={{paper: classes.cropperDialogPaper}} open={true} disableBackdropClick={true} onKeyDown={this.onKeyDown}>
           <div className={classes.cropperOuterContainer}>
             <div className={classes.cropperContainer} style={cropperContainerStyle}>
               <div id={this.containerId} />

--- a/packages/rewire-ui/src/components/AvatarField.tsx
+++ b/packages/rewire-ui/src/components/AvatarField.tsx
@@ -251,7 +251,7 @@ const InnerAvatar = withStyles(innerAvatarStyles, class extends React.Component<
       this.props.value
         ? < >
             <MuiAvatar src={this.props.value} className={classes.muiAvatar} style={{width: diameterStr, height: diameterStr}} />
-            <Button variant='contained' component='label' size={bSize} className={classNames(classes.button, classes.changeImageButton)}>
+            <Button variant='contained' component='label' size={bSize} tabIndex={-1} className={classNames(classes.button, classes.changeImageButton)}>
               <span>Change Image</span>
               <label className={classes.changeImageButtonInnerLabel} htmlFor={fileInputId} />
               <input {...fileInputProps} />

--- a/packages/rewire-ui/src/components/ColorField.tsx
+++ b/packages/rewire-ui/src/components/ColorField.tsx
@@ -128,7 +128,7 @@ class ColorField extends React.Component<ColorFieldPropsStyled, IColorFieldState
   handleKeyDown = (evt: React.KeyboardEvent<any>) => {
     switch (evt.key) {
       case 'Enter':
-      if (!this.state.open) break;
+        if (!this.state.open) return;
         if (evt.repeat) break;
         this.handleClose(evt, 'backdropClick');
       case ' ':
@@ -140,6 +140,7 @@ class ColorField extends React.Component<ColorFieldPropsStyled, IColorFieldState
         }
         break;
       case 'Escape':
+        if (!this.state.open) return;
         if (evt.repeat) break;
         this.focusColorPickerTrigger();
         break;

--- a/packages/rewire-ui/src/components/MultiSelectAutoComplete.tsx
+++ b/packages/rewire-ui/src/components/MultiSelectAutoComplete.tsx
@@ -379,7 +379,7 @@ class MultiSelectAutoComplete<T> extends React.Component<MultiSelectAutoComplete
     }
   }
 
-  handleKeyDown = (event: React.KeyboardEvent<any>) => {
+  handleKeyDown = (event: any) => {
     if (event.altKey || event.ctrlKey) {
       return;
     }
@@ -409,6 +409,14 @@ class MultiSelectAutoComplete<T> extends React.Component<MultiSelectAutoComplete
           event.preventDefault();
           event.stopPropagation();
           event.nativeEvent.stopImmediatePropagation();
+        }
+        break;
+      case 27:
+        const st = this.downShift.getState();
+        if (st.isOpen) {
+          event.nativeEvent.preventDownshiftDefault = false;
+        } else {
+          event.nativeEvent.preventDownshiftDefault = true;
         }
         break;
       case 37:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,14 +1557,14 @@
   integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
 
 "@types/node@*", "@types/node@^11.11.3":
-  version "11.13.4"
-  resolved "https://npm.worksight.services/@types%2fnode/-/node-11.13.4.tgz#f83ec3c3e05b174b7241fadeb6688267fe5b22ca"
-  integrity sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==
+  version "11.13.5"
+  resolved "https://npm.worksight.services/@types%2fnode/-/node-11.13.5.tgz#266564afa8a6a09dc778dfacc703ed3f09c80516"
+  integrity sha512-/OMMBnjVtDuwX1tg2pkYVSqRIDSmNTnvVvmvP/2xiMAAWf4a5+JozrApCrO4WCAILmXVxfNoQ3E+0HJbNpFVGg==
 
 "@types/prop-types@*":
-  version "15.7.0"
-  resolved "https://npm.worksight.services/@types%2fprop-types/-/prop-types-15.7.0.tgz#4c48fed958d6dcf9487195a0ef6456d5f6e0163a"
-  integrity sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg==
+  version "15.7.1"
+  resolved "https://npm.worksight.services/@types%2fprop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
+  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
 
 "@types/q@^1.5.1":
   version "1.5.2"
@@ -5747,22 +5747,17 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-"mime-db@>= 1.38.0 < 2":
+"mime-db@>= 1.38.0 < 2", mime-db@~1.39.0:
   version "1.39.0"
   resolved "https://npm.worksight.services/mime-db/-/mime-db-1.39.0.tgz#f95a20275742f7d2ad0429acfe40f4233543780e"
   integrity sha512-DTsrw/iWVvwHH+9Otxccdyy0Tgiil6TWK/xhfARJZF/QFhwOgZgOIvA2/VIGpM8U7Q8z5nDmdDWC6tuVMJNibw==
 
-mime-db@~1.38.0:
-  version "1.38.0"
-  resolved "https://npm.worksight.services/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
-  integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
-
 mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
-  version "2.1.22"
-  resolved "https://npm.worksight.services/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd"
-  integrity sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==
+  version "2.1.23"
+  resolved "https://npm.worksight.services/mime-types/-/mime-types-2.1.23.tgz#d4eacd87de99348a6858fe1e479aad877388d977"
+  integrity sha512-ROk/m+gMVSrRxTkMlaQOvFmFmYDc7sZgrjjM76abqmd2Cc5fCV7jAMA5XUccEtJ3cYiYdgixUVI+fApc2LkXlw==
   dependencies:
-    mime-db "~1.38.0"
+    mime-db "~1.39.0"
 
 mime@1.4.1:
   version "1.4.1"


### PR DESCRIPTION
…d twice on tab navigation. Will no longer take two tabs to navigate to the next element.

    - Avatar Field crop window, made working keybinds for cancel and save (Escape and Enter, respectively).
    - ColorField,  AutoComplete, and MultiSelectAutoComplete fields will now properly propogate the 'Escape" keydown event if they do not have a state of open (open color picker or open suggestions menu). This results in an open dialog properly closing when focusing these elements and the 'Escape' key is pressed.
    - Exiting a dialog will now cause the previously focused element (before the dialog was opened) to be re-focused.