### PR TITLE
Rewire-ui: - StaticField now has a label that is the same color as ot…

### DIFF
--- a/examples/src/AboutView.tsx
+++ b/examples/src/AboutView.tsx
@@ -47,6 +47,7 @@ class TestDialog extends Modal {
     date                 : Form.date().label('Date').validators(isRequired).autoFocus(),
     dollars              : Form.number().label('Dollars').validators(isRequired).placeholder('Show me the money').startAdornment(() => <div style={{display: 'flex', alignItems: 'center'}}><AddIcon /><span>$</span></div>),
     shouldI              : Form.multiselect(searcher).label('Should I?').placeholder('choose!').startAdornment(() => <AccessibilityIcon />).validators(isRequired),
+    static               : Form.static().label('Static'),
     isGreat              : Form.boolean().label('Is Great'),
     noLabel              : Form.boolean(),
     disabled             : Form.boolean().label('Disabled').disabled(() => true),
@@ -66,7 +67,7 @@ class TestDialog extends Modal {
     switch1              : Form.switch().label('Switch 1'),
     switch2              : Form.switch().label('Switch 2'),
     color                : Form.color().disabled(() => false).label('Colour picker'),
-  }, {email: 'splace@worksight.net', isGreat: true, switch2: true, phone: '34232221535'}, {variant: 'outlined', initialValuesValidationMode: 'withValues'});
+  }, {email: 'splace@worksight.net', static: `Can't Change Me`, isGreat: true, switch2: true, phone: '34232221535'}, {variant: 'outlined', initialValuesValidationMode: 'withValues'});
 }
 
 const testDialog   = new TestDialog();
@@ -75,38 +76,39 @@ const TestFormView = ({form}: {form: typeof testDialog.form}) => (
       <div style={{fontSize: '16px'}}>
         <FormView form={form} onSubmit={testDialog.actionFn('login')}>
           <div className='content'>
-            <form.field.date.Editor    className='span4' />
-            <form.field.dollars.Editor className='span4' />
-            <form.field.shouldI.Editor className='span4' />
+            <form.field.date.Editor    className='span1' />
+            <form.field.dollars.Editor className='span1' />
+            <form.field.shouldI.Editor className='span1' />
+            <form.field.static.Editor  className='span1' />
           </div>
           <div className='content'>
-            <form.field.noLabel.Editor  className='span4' />
-            <form.field.disabled.Editor className='span4' />
-            <form.field.email.Editor    className='span4' />
-            <form.field.name.Editor     className='span4' />
+            <form.field.noLabel.Editor  className='span1' />
+            <form.field.disabled.Editor className='span1' />
+            <form.field.email.Editor    className='span1' />
+            <form.field.name.Editor     className='span1' />
           </div>
           <div className='content'>
-            <form.field.password.Editor />
-            <form.field.password_confirmation.Editor />
-            <form.field.phone.Editor />
-            <form.field.phoneCustom.Editor />
+            <form.field.password.Editor              className='span1' />
+            <form.field.password_confirmation.Editor className='span1' />
+            <form.field.phone.Editor                 className='span1' />
+            <form.field.phoneCustom.Editor           className='span1' />
           </div>
           <div className='content'>
-            <form.field.timeOut.Editor className='span4' />
-            <form.field.timeIn.Editor  className='span4' />
-            <form.field.isGreat.Editor className='span4' />
+            <form.field.timeOut.Editor className='span1' />
+            <form.field.timeIn.Editor  className='span1' />
+            <form.field.isGreat.Editor className='span2' />
           </div>
           <div className='content'>
             <form.field.difference.Editor className='span1' />
             <form.field.sum.Editor        className='span1' />
-            <form.field.multi.Editor      className='span1' />
+            <form.field.multi.Editor      className='span2' />
           </div>
           {/* <Slide in={true} timeout={2000} direction='up' mountOnEnter unmountOnExit> */}
           <div className='content'>
             <form.field.switch1.Editor className='span1' />
             <form.field.switch2.Editor className='span1' />
             <form.field.color.Editor   className='span1' />
-            <form.field.country.Editor className='span4' />
+            <form.field.country.Editor className='span1' />
           </div>
           {/* </Slide> */}
           <div className='content'>

--- a/examples/src/graphqltest.ts
+++ b/examples/src/graphqltest.ts
@@ -77,7 +77,7 @@ async function run() {
   client.use(uploadMiddleware);
   client.use((q, req, next) => {
     next();
-  })
+  });
   // console.log(await client.query(employees));
   // const r = client.subscribe(subscriptionQuery);
   // r.observe((data: any) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "WorkSight .NEXT core",
   "main": "src/index.js",
   "private": true,

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/src/client.ts
+++ b/packages/rewire-graphql/src/client.ts
@@ -75,7 +75,7 @@ class Client implements IClient {
             const fn = this.middleware[i++];
             if (!fn) return;
             fn(queryObject, reqInit, next);
-          }
+          };
           next();
         }
 

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-grid/src/models/GridTypes.ts
+++ b/packages/rewire-grid/src/models/GridTypes.ts
@@ -220,7 +220,7 @@ export interface IGridFontSizes {
 }
 
 export interface IToggleableColumnsOptions {
-  onItemClick?(item: IToggleMenuItem): () => void;
+  onItemClick?(item: IToggleMenuItem): void;
 }
 
 export interface IRowOptions {

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-ui/src/components/AutoComplete.tsx
+++ b/packages/rewire-ui/src/components/AutoComplete.tsx
@@ -66,8 +66,12 @@ const styles = (theme: Theme) => ({
   inputLabelRoot: {
     fontSize: 'inherit',
   },
-  inputLabelRootShrink: {
-    transform: 'translate(14px, -0.375em) scale(0.75) !important',
+  inputLabelOutlined: {
+    '&$inputLabelShrink': {
+      transform: 'translate(14px, -0.375em) scale(0.75)',
+    },
+  },
+  inputLabelShrink: {
   },
   inputFormControlWithLabel: {
     marginTop: '1em !important',
@@ -177,7 +181,7 @@ class AutoComplete<T> extends React.Component<AutoCompleteProps<T>, any> {
         onFocus={this.handleFocus}
         inputProps={{spellCheck: false, className: classes.nativeInput, style: {textAlign: align || 'left'}}}
         InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, input: inputClassName, formControl: inputFormControlClassName}}}
-        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelRootShrink}}}
+        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
         FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
         {...other}
       />

--- a/packages/rewire-ui/src/components/ColorField.tsx
+++ b/packages/rewire-ui/src/components/ColorField.tsx
@@ -17,8 +17,12 @@ const styles = (theme: Theme) => ({
   inputLabelRoot: {
     fontSize: 'inherit',
   },
-  inputLabelRootShrink: {
-    transform: 'translate(0, -0.375em) scale(0.75) !important',
+  inputLabelOutlined: {
+    '&$inputLabelShrink': {
+      transform: 'translate(0, -0.375em) scale(0.75)',
+    },
+  },
+  inputLabelShrink: {
   },
   colorFieldContainerNoLabel: {
     display: 'flex',
@@ -232,7 +236,7 @@ class ColorField extends React.Component<ColorFieldPropsStyled, IColorFieldState
         onKeyDown={this.handleKeyDown}
         onKeyUp={this.handleKeyUp}
       >
-        {label && <InputLabel htmlFor='rc-color-picker-trigger' shrink={true} variant={variant} classes={{root: classes.inputLabelRoot, outlined: classes.inputLabelRootShrink}}>{label}</InputLabel>}
+        {label && <InputLabel htmlFor='rc-color-picker-trigger' shrink={true} variant={variant} classes={{root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}>{label}</InputLabel>}
         {this.renderColorPicker(value)}
       </FormControl>
     );

--- a/packages/rewire-ui/src/components/MaskField.tsx
+++ b/packages/rewire-ui/src/components/MaskField.tsx
@@ -37,8 +37,12 @@ const styles = (theme: Theme) => ({
   inputLabelRoot: {
     fontSize: 'inherit',
   },
-  inputLabelRootShrink: {
-    transform: 'translate(14px, -0.375em) scale(0.75) !important',
+  inputLabelOutlined: {
+    '&$inputLabelShrink': {
+      transform: 'translate(14px, -0.375em) scale(0.75)',
+    },
+  },
+  inputLabelShrink: {
   },
   inputFormControlWithLabel: {
     marginTop: '1em !important',
@@ -267,7 +271,7 @@ class MaskField extends React.Component<MaskFieldProps> {
         onChange={(evt: React.ChangeEvent<HTMLInputElement>) => this.props.onValueChange(evt.target.value)}
         inputProps={{spellCheck: false, className: classes.nativeInput, style: {textAlign: this.props.align || 'left'}, ...maskProps}}
         InputProps={{inputComponent: TextMaskCustom, startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, input: inputClassName, inputType: classes.inputType, formControl: inputFormControlClassName}}}
-        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelRootShrink}}}
+        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
         FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
       />);
     }
@@ -291,7 +295,7 @@ class MaskField extends React.Component<MaskFieldProps> {
           onChange={props.onChange}
           inputProps={{spellCheck: false, className: classes.nativeInput, style: {textAlign: props.align || 'left'}, ...maskProps}}
           InputProps={{inputComponent: TextMaskCustom, startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, input: inputClassName, inputType: classes.inputType, formControl: inputFormControlClassName}}}
-          InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelRootShrink}}}
+          InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
           FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
         />
       }

--- a/packages/rewire-ui/src/components/MultiSelectAutoComplete.tsx
+++ b/packages/rewire-ui/src/components/MultiSelectAutoComplete.tsx
@@ -75,8 +75,12 @@ const styles = (theme: Theme) => ({
   inputLabelRoot: {
     fontSize: 'inherit',
   },
-  inputLabelRootShrink: {
-    transform: 'translate(14px, -0.375em) scale(0.75) !important',
+  inputLabelOutlined: {
+    '&$inputlabelShrink': {
+      transform: 'translate(14px, -0.375em) scale(0.75)',
+    },
+  },
+  inputLabelShrink: {
   },
   inputFormControlWithLabel: {
     marginTop: '1em !important',
@@ -181,7 +185,7 @@ class MultiSelectAutoComplete<T> extends React.Component<MultiSelectAutoComplete
         onFocus={this.handleFocus}
         inputProps={{spellCheck: false, className: classes.nativeInput, style: {textAlign: align || 'left'}}}
         InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, input: inputClassName, formControl: inputFormControlClassName}}}
-        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelRootShrink}}}
+        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
         FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
         {...other}
       />

--- a/packages/rewire-ui/src/components/NumberField.tsx
+++ b/packages/rewire-ui/src/components/NumberField.tsx
@@ -24,8 +24,12 @@ const styles = (theme: Theme) => ({
   inputLabelRoot: {
     fontSize: 'inherit',
   },
-  inputLabelRootShrink: {
-    transform: 'translate(14px, -0.375em) scale(0.75) !important',
+  inputLabelOutlined: {
+    '&$inputLabelShrink': {
+      transform: 'translate(14px, -0.375em) scale(0.75)',
+    },
+  },
+  inputLabelShrink: {
   },
   inputFormControlWithLabel: {
     marginTop: '1em !important',
@@ -167,7 +171,7 @@ class NumberTextField extends React.Component<NumberFieldProps> {
           isNumericString={this.props.isNumericString}
           inputProps={{spellCheck: false, className: this.props.classes.nativeInput, style: {textAlign: this.props.align || 'left'}}}
           InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: this.props.classes.inputRoot, input: inputClassName, formControl: inputFormControlClassName}}}
-          InputLabelProps={{shrink: true, classes: {root: this.props.classes.inputLabelRoot, outlined: this.props.classes.inputLabelRootShrink}}}
+          InputLabelProps={{shrink: true, classes: {root: this.props.classes.inputLabelRoot, outlined: this.props.classes.inputLabelOutlined}}}
           FormHelperTextProps={{classes: {root: this.props.classes.helperTextRoot, contained: this.props.classes.helperTextContained}}}
           customInput={TextField}
           placeholder={this.props.placeholder}
@@ -202,7 +206,7 @@ class NumberTextField extends React.Component<NumberFieldProps> {
             isNumericString={props.isNumericString}
             inputProps={{spellCheck: false, className: props.classes.nativeInput, style: {textAlign: props.align || 'left'}}}
             InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: props.classes.inputRoot, input: inputClassName, formControl: inputFormControlClassName}}}
-            InputLabelProps={{shrink: true, classes: {root: props.classes.inputLabelRoot, outlined: props.classes.inputLabelRootShrink}}}
+            InputLabelProps={{shrink: true, classes: {root: props.classes.inputLabelRoot, outlined: props.classes.inputLabelOutlined}}}
             FormHelperTextProps={{classes: {root: props.classes.helperTextRoot, contained: props.classes.helperTextContained}}}
             customInput={TextField}
             placeholder={props.placeholder}

--- a/packages/rewire-ui/src/components/PasswordField.tsx
+++ b/packages/rewire-ui/src/components/PasswordField.tsx
@@ -25,8 +25,12 @@ const styles = (theme: Theme) => ({
   inputLabelRoot: {
     fontSize: 'inherit',
   },
-  inputLabelRootShrink: {
-    transform: 'translate(14px, -0.375em) scale(0.75) !important',
+  inputLabelOutlined: {
+    '&$inputLabelShrink': {
+      transform: 'translate(14px, -0.375em) scale(0.75)',
+    },
+  },
+  inputLabelShrink: {
   },
   inputFormControlWithLabel: {
     marginTop: '1em !important',
@@ -176,7 +180,7 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
           onChange={(evt: React.ChangeEvent<HTMLInputElement>) => this.props.onValueChange(evt.target.value)}
           inputProps={{spellCheck: false, className: this.props.classes.nativeInput, style: {textAlign: this.props.align || 'left'}}}
           InputProps={{endAdornment: adornment, classes: {root: this.props.classes.inputRoot, input: inputClassName, inputType: this.props.classes.inputType, formControl: inputFormControlClassName}}}
-          InputLabelProps={{shrink: true, classes: {root: this.props.classes.inputLabelRoot, outlined: this.props.classes.inputLabelRootShrink}}}
+          InputLabelProps={{shrink: true, classes: {root: this.props.classes.inputLabelRoot, outlined: this.props.classes.inputLabelOutlined}}}
           FormHelperTextProps={{classes: {root: this.props.classes.helperTextRoot, contained: this.props.classes.helperTextContained}}}
         />
       );
@@ -203,7 +207,7 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
             onChange={props.onChange}
             inputProps={{spellCheck: false, className: props.classes.nativeInput, style: {textAlign: props.align || 'left'}}}
             InputProps={{endAdornment: adornment, classes: {root: props.classes.inputRoot, input: inputClassName, inputType: props.classes.inputType, formControl: inputFormControlClassName}}}
-            InputLabelProps={{shrink: true, classes: {root: props.classes.inputLabelRoot, outlined: props.classes.inputLabelRootShrink}}}
+            InputLabelProps={{shrink: true, classes: {root: props.classes.inputLabelRoot, outlined: props.classes.inputLabelOutlined}}}
             FormHelperTextProps={{classes: {root: props.classes.helperTextRoot, contained: props.classes.helperTextContained}}}
           />
         }

--- a/packages/rewire-ui/src/components/Select.tsx
+++ b/packages/rewire-ui/src/components/Select.tsx
@@ -37,8 +37,12 @@ const styles = (theme: Theme) => ({
   inputLabelRoot: {
     fontSize: 'inherit',
   },
-  inputLabelRootShrink: {
-    transform: 'translate(14px, -0.375em) scale(0.75) !important',
+  inputLabelOutlined: {
+    '&$inputLabelShrink': {
+      transform: 'translate(14px, -0.375em) scale(0.75)',
+    },
+  },
+  inputLabelShrink: {
   },
   inputFormControlWithLabel: {
     marginTop: '1em !important',
@@ -383,7 +387,7 @@ class SelectInternal<T> extends React.Component<SelectInternalProps<T>, any> {
     let   cls   = (this.props.className || '') + ' select';
     return (
       <FormControl error={!disableErrors && !disabled && !!error} variant={variant} className={classNames(cls, classes.formControlRoot)}>
-        {label && <RootRef rootRef={this.InputLabelRef}><InputLabel htmlFor='name-error' shrink={true} classes={{root: classes.inputLabelRoot, outlined: classes.inputLabelRootShrink}}>{label}</InputLabel></RootRef>}
+        {label && <RootRef rootRef={this.InputLabelRef}><InputLabel htmlFor='name-error' shrink={true} classes={{root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}>{label}</InputLabel></RootRef>}
         {this.renderSelect(disabled, '', this.props.selectedItem, this.props.autoFocus, this.props.placeholder)}
         {!disableErrors && <FormHelperText classes={{root: classes.helperTextRoot, contained: classes.helperTextContained}}>{!disabled && error}</FormHelperText>}
       </FormControl>

--- a/packages/rewire-ui/src/components/StaticField.tsx
+++ b/packages/rewire-ui/src/components/StaticField.tsx
@@ -14,9 +14,11 @@ const styles = (theme: Theme) => ({
   },
   inputLabelRoot: {
     fontSize: 'inherit',
+    '&$inputLabelDisabled': {
+      color: theme.palette.text.secondary,
+    },
   },
-  inputLabelRootShrink: {
-    transform: 'translate(14px, -0.375em) scale(0.75) !important',
+  inputLabelDisabled: {
   },
 });
 
@@ -62,7 +64,7 @@ class StaticFieldInternal extends React.Component<StaticFieldProps> {
         value={value}
         type={this.props.type}
         onChange={(evt: React.ChangeEvent<HTMLInputElement>) => this.props.onValueChange(evt.target.value)}
-        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelRootShrink}}}
+        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, disabled: classes.inputLabelDisabled}}}
         InputProps={{style: {color: 'inherit'}, classes: {root: classes.inputRoot}}}
         inputProps={{spellCheck: false, style: {textAlign: this.props.align || 'left'}}}
       />);

--- a/packages/rewire-ui/src/components/TextField.tsx
+++ b/packages/rewire-ui/src/components/TextField.tsx
@@ -35,8 +35,12 @@ const styles = (theme: Theme) => ({
   inputLabelRoot: {
     fontSize: 'inherit',
   },
-  inputLabelRootShrink: {
-    transform: 'translate(14px, -0.375em) scale(0.75) !important',
+  inputLabelOutlined: {
+    '&$inputLabelShrink': {
+      transform: 'translate(14px, -0.375em) scale(0.75)',
+    },
+  },
+  inputLabelShrink: {
   },
   inputFormControlWithLabel: {
     marginTop: '1em !important',
@@ -213,7 +217,7 @@ class TextFieldInternal extends React.Component<TextFieldPropsStyled> {
         onChange={(evt: React.ChangeEvent<HTMLInputElement>) => this.props.onValueChange(evt.target.value)}
         inputProps={{spellCheck: !!multiline, className: classes.nativeInput, style: {textAlign: this.props.align || 'left'}}}
         InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, multiline: multilineClassName, input: inputClassName, inputType: inputTypeClassName, formControl: inputFormControlClassName}}}
-        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelRootShrink}}}
+        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
         FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
       />);
     }
@@ -242,7 +246,7 @@ class TextFieldInternal extends React.Component<TextFieldPropsStyled> {
           onChange={props.onChange}
           inputProps={{spellCheck: !!multiline, className: classes.nativeInput, style: {textAlign: props.align || 'left'}}}
           InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, multiline: multilineClassName, input: inputClassName, inputType: inputTypeClassName, formControl: inputFormControlClassName}}}
-          InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelRootShrink}}}
+          InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
           FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
         />
       }

--- a/packages/rewire-ui/src/components/TimeInputField.tsx
+++ b/packages/rewire-ui/src/components/TimeInputField.tsx
@@ -129,8 +129,12 @@ const styles = (theme: Theme) => ({
   inputLabelRoot: {
     fontSize: 'inherit',
   },
-  inputLabelRootShrink: {
-    transform: 'translate(14px, -0.375em) scale(0.75) !important',
+  inputLabelOutlined: {
+    '&$inputLabelShrink': {
+      transform: 'translate(14px, -0.375em) scale(0.75)',
+    },
+  },
+  inputLabelShrink: {
   },
   inputFormControlWithLabel: {
     marginTop: '1em !important',
@@ -277,7 +281,7 @@ class TimeInputField extends React.Component<TimeFieldProps, ITimeState> {
         variant={variant}
         inputProps={{spellCheck: false, className: classes.nativeInput, style: {textAlign: align || 'left'}}}
         InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, input: inputClassName, formControl: inputFormControlClassName}}}
-        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelRootShrink}}}
+        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
         FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
       />);
   }

--- a/packages/rewire-ui/src/components/ToggleMenu.tsx
+++ b/packages/rewire-ui/src/components/ToggleMenu.tsx
@@ -42,7 +42,7 @@ interface IToggleMenuProps {
   buttonProps:   ButtonProps;
   items:         IToggleMenuItem[];
 
-  onItemClick?(item: IToggleMenuItem): () => void;
+  onItemClick?(item: IToggleMenuItem): void;
 }
 
 interface IToggleMenuState {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,9 +1365,9 @@
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
 "@octokit/endpoint@^4.0.0":
-  version "4.0.0"
-  resolved "https://npm.worksight.services/@octokit%2fendpoint/-/endpoint-4.0.0.tgz#97032a6690ef1cf9576ab1b1582c0ac837e3b5b6"
-  integrity sha512-b8sptNUekjREtCTJFpOfSIL4SKh65WaakcyxWzRcSPOk5RxkZJ/S8884NGZFxZ+jCB2rDURU66pSHn14cVgWVg==
+  version "4.1.1"
+  resolved "https://npm.worksight.services/@octokit%2fendpoint/-/endpoint-4.1.1.tgz#847075b85157c7bd60d0f23c426b23bed8a232dd"
+  integrity sha512-lfphGC9hglBDiIOU84f1xDUzjWE5j3jGkO3Ng/IpDDVARw760A+/x408JOEpdV20ZUj2GRWdDBC0+HPu5qA5gQ==
   dependencies:
     deepmerge "3.2.0"
     is-plain-object "^2.0.4"
@@ -1480,9 +1480,9 @@
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
 "@types/express-serve-static-core@*":
-  version "4.16.2"
-  resolved "https://npm.worksight.services/@types%2fexpress-serve-static-core/-/express-serve-static-core-4.16.2.tgz#5ee8a22e602005be6767df6b2cba9879df3f75aa"
-  integrity sha512-qgc8tjnDrc789rAQed8NoiFLV5VGcItA4yWNFphqGU0RcuuQngD00g3LHhWIK3HQ2XeDgVCmlNPDlqi3fWBHnQ==
+  version "4.16.3"
+  resolved "https://npm.worksight.services/@types%2fexpress-serve-static-core/-/express-serve-static-core-4.16.3.tgz#49d9cea50e801f8bf757702060752fe65f169ba7"
+  integrity sha512-HFgBmRDTvdnrRFXqBr2NM2NUCu6fIpzJsUTlRVENF8lxvstof7cl9Fxfwq5S0kJbO/FsPVcjlxpOM3ZxIkn7Rw==
   dependencies:
     "@types/node" "*"
     "@types/range-parser" "*"
@@ -2577,9 +2577,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000960:
-  version "1.0.30000962"
-  resolved "https://npm.worksight.services/caniuse-lite/-/caniuse-lite-1.0.30000962.tgz#6c10c3ab304b89bea905e66adf98c0905088ee44"
-  integrity sha512-WXYsW38HK+6eaj5IZR16Rn91TGhU3OhbwjKZvJ4HN/XBIABLKfbij9Mnd3pM0VEwZSlltWjoWg3I8FQ0DGgNOA==
+  version "1.0.30000963"
+  resolved "https://npm.worksight.services/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz#5be481d5292f22aff5ee0db4a6c049b65b5798b1"
+  integrity sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -5366,9 +5366,9 @@ nanomatch@^1.2.9:
     to-regex "^3.0.1"
 
 needle@^2.2.1:
-  version "2.3.0"
-  resolved "https://npm.worksight.services/needle/-/needle-2.3.0.tgz#ce3fea21197267bacb310705a7bbe24f2a3a3492"
-  integrity sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==
+  version "2.3.1"
+  resolved "https://npm.worksight.services/needle/-/needle-2.3.1.tgz#d272f2f4034afb9c4c9ab1379aabc17fc85c9388"
+  integrity sha512-CaLXV3W8Vnbps8ZANqDGz7j4x7Yj1LW4TWF/TQuDfj7Cfx4nAPTvw98qgTevtto1oHDrh3pQkaODbqupXlsWTg==
   dependencies:
     debug "^4.1.0"
     iconv-lite "^0.4.4"
@@ -5454,9 +5454,9 @@ node-pre-gyp@^0.12.0:
     tar "^4"
 
 node-releases@^1.1.14:
-  version "1.1.16"
-  resolved "https://npm.worksight.services/node-releases/-/node-releases-1.1.16.tgz#efcb6615b0e8dc454bfb03bc025aad406ea6dddf"
-  integrity sha512-BOMWCW9CaT4sffMa5S9Mj4vYObvVShyo6JoM9WzzQOKVyNUn1+OVMUaQT3fo2tJKCMwHjqaDW/Pf3/JsYmPD2g==
+  version "1.1.17"
+  resolved "https://npm.worksight.services/node-releases/-/node-releases-1.1.17.tgz#71ea4631f0a97d5cd4f65f7d04ecf9072eac711a"
+  integrity sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==
   dependencies:
     semver "^5.3.0"
 
@@ -6906,9 +6906,9 @@ resolve-url@^0.2.1:
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 resolve@^1.10.0, resolve@^1.3.2:
-  version "1.10.0"
-  resolved "https://npm.worksight.services/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
-  integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
+  version "1.10.1"
+  resolved "https://npm.worksight.services/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
+  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
   dependencies:
     path-parse "^1.0.6"
 
@@ -7652,9 +7652,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^3.3.3333:
-  version "3.4.4"
-  resolved "https://npm.worksight.services/typescript/-/typescript-3.4.4.tgz#aac4a08abecab8091a75f10842ffa0631818f785"
-  integrity sha512-xt5RsIRCEaf6+j9AyOBgvVuAec0i92rgCaS3S+UVf5Z/vF2Hvtsw08wtUTJqp4djwznoAgjSxeCcU4r+CcDBJA==
+  version "3.4.5"
+  resolved "https://npm.worksight.services/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"
@@ -7670,9 +7670,9 @@ uglify-es@^3.3.9:
     source-map "~0.6.1"
 
 uglify-js@^3.1.4:
-  version "3.5.6"
-  resolved "https://npm.worksight.services/uglify-js/-/uglify-js-3.5.6.tgz#8a5f8a06ee7415ac1fa302f4623bc7344b553da4"
-  integrity sha512-YDKRX8F0Y+Jr7LhoVk0n4G7ltR3Y7qFAj+DtVBthlOgCcIj1hyMigCfousVfn9HKmvJ+qiFlLDwaHx44/e5ZKw==
+  version "3.5.7"
+  resolved "https://npm.worksight.services/uglify-js/-/uglify-js-3.5.7.tgz#1442fda9991a01aa0eb2853876640477109113ff"
+  integrity sha512-GCgJx3BBuaf/QMvBBkhoHDh4SVsHCC3ILEzriPw4FgJJKCuxVBSYLRkDlmT3uhXyGWKs3VN5r0mCkBIZaHWu3w==
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
…her input fields (no longer the disabled color).

    - properly overrode material-ui styles that were defined with two or more classes, allowing for the removal of the !important tag on those style rules.
    - corrected the typing of the onItemClick method for the ToggleMenu props
Rewire-Grid: - corrected the typing of the onItemClick method in IToggleableColumnsOptions.

- added an example of a static field to the AboutView example page.