### PR TITLE
Rewire-ui: - MultiSelectAutoComplete can now have a start adornment. …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "WorkSight .NEXT core",
   "main": "src/index.js",
   "private": true,

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-ui/src/components/ColorField.tsx
+++ b/packages/rewire-ui/src/components/ColorField.tsx
@@ -236,7 +236,7 @@ class ColorField extends React.Component<ColorFieldPropsStyled, IColorFieldState
         onKeyDown={this.handleKeyDown}
         onKeyUp={this.handleKeyUp}
       >
-        {label && <InputLabel htmlFor='rc-color-picker-trigger' shrink={true} variant={variant} classes={{root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}>{label}</InputLabel>}
+        {label && <InputLabel htmlFor='rc-color-picker-trigger' shrink={true} variant={variant} classes={{root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined, shrink: classes.inputLabelShrink}}>{label}</InputLabel>}
         {this.renderColorPicker(value)}
       </FormControl>
     );

--- a/packages/rewire-ui/src/components/MaskField.tsx
+++ b/packages/rewire-ui/src/components/MaskField.tsx
@@ -271,7 +271,7 @@ class MaskField extends React.Component<MaskFieldProps> {
         onChange={(evt: React.ChangeEvent<HTMLInputElement>) => this.props.onValueChange(evt.target.value)}
         inputProps={{spellCheck: false, className: classes.nativeInput, style: {textAlign: this.props.align || 'left'}, ...maskProps}}
         InputProps={{inputComponent: TextMaskCustom, startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, input: inputClassName, inputType: classes.inputType, formControl: inputFormControlClassName}}}
-        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
+        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined, shrink: classes.inputLabelShrink}}}
         FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
       />);
     }
@@ -295,7 +295,7 @@ class MaskField extends React.Component<MaskFieldProps> {
           onChange={props.onChange}
           inputProps={{spellCheck: false, className: classes.nativeInput, style: {textAlign: props.align || 'left'}, ...maskProps}}
           InputProps={{inputComponent: TextMaskCustom, startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, input: inputClassName, inputType: classes.inputType, formControl: inputFormControlClassName}}}
-          InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
+          InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined, shrink: classes.inputLabelShrink}}}
           FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
         />
       }

--- a/packages/rewire-ui/src/components/MultiSelectAutoComplete.tsx
+++ b/packages/rewire-ui/src/components/MultiSelectAutoComplete.tsx
@@ -76,7 +76,7 @@ const styles = (theme: Theme) => ({
     fontSize: 'inherit',
   },
   inputLabelOutlined: {
-    '&$inputlabelShrink': {
+    '&$inputLabelShrink': {
       transform: 'translate(14px, -0.375em) scale(0.75)',
     },
   },
@@ -134,9 +134,13 @@ interface IMultiSelectAutoCompleteProps {
   suggestionsContainerFooter?: ISuggestionsContainerComponent;
 }
 
+interface IMultiSelectAutoCompleteState {
+  suggestions: any[];
+}
+
 export type MultiSelectAutoCompleteProps<T> = WithStyle<ReturnType<typeof styles>, IMultiSelectAutoCompleteProps & ICustomProps<T> & React.InputHTMLAttributes<any>>;
 
-class MultiSelectAutoComplete<T> extends React.Component<MultiSelectAutoCompleteProps<T>, any> {
+class MultiSelectAutoComplete<T> extends React.Component<MultiSelectAutoCompleteProps<T>, IMultiSelectAutoCompleteState> {
   state = {suggestions: []};
   downShift:                any;
   search:                   SearchFn<T>;
@@ -182,10 +186,9 @@ class MultiSelectAutoComplete<T> extends React.Component<MultiSelectAutoComplete
         inputRef={ref}
         disabled={disabled}
         autoFocus={autoFocus}
-        onFocus={this.handleFocus}
         inputProps={{spellCheck: false, className: classes.nativeInput, style: {textAlign: align || 'left'}}}
         InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, input: inputClassName, formControl: inputFormControlClassName}}}
-        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
+        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined, shrink: classes.inputLabelShrink}}}
         FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
         {...other}
       />
@@ -440,6 +443,7 @@ class MultiSelectAutoComplete<T> extends React.Component<MultiSelectAutoComplete
     const selectedItem  = this.map(item);
     selectedItems.splice(selectedItems.findIndex(i => this.map(i) === selectedItem), 1);
     this.props.onSelectItem && this.props.onSelectItem(selectedItems);
+    this.suggestionsContainerNode.focus();
   }
 
   handleMenuMouseDown = (event: React.MouseEvent<any>) => {
@@ -479,21 +483,20 @@ class MultiSelectAutoComplete<T> extends React.Component<MultiSelectAutoComplete
   }
 
   shouldComponentUpdate(nextProps: ICustomProps<T> & React.InputHTMLAttributes<any>, nextState: any, nextContext: any) {
-    return true;
-    // return (
-    //     (nextProps.selectedItem !== this.props.selectedItem) ||
-    //     (nextProps.error !== this.props.error) ||
-    //     (nextProps.disabled !== this.props.disabled) ||
-    //     (nextProps.visible !== this.props.visible) ||
-    //     (nextState.suggestions !== this.state.suggestions) ||
-    //     (nextProps.label !== this.props.label) ||
-    //     (nextProps.placeholder !== this.props.placeholder) ||
-    //     (nextProps.align !== this.props.align) ||
-    //     (nextProps.variant !== this.props.variant) ||
-    //     (nextProps.disableErrors !== this.props.disableErrors) ||
-    //     (nextProps.startAdornment !== this.props.startAdornment) ||
-    //     (nextProps.endAdornment !== this.props.endAdornment)
-    //   );
+    return (
+        (nextProps.selectedItems !== this.props.selectedItems) ||
+        (nextProps.error !== this.props.error) ||
+        (nextProps.disabled !== this.props.disabled) ||
+        (nextProps.visible !== this.props.visible) ||
+        (nextState.suggestions !== this.state.suggestions) ||
+        (nextProps.label !== this.props.label) ||
+        (nextProps.placeholder !== this.props.placeholder) ||
+        (nextProps.align !== this.props.align) ||
+        (nextProps.variant !== this.props.variant) ||
+        (nextProps.disableErrors !== this.props.disableErrors) ||
+        (nextProps.startAdornment !== this.props.startAdornment) ||
+        (nextProps.endAdornment !== this.props.endAdornment)
+      );
   }
 
   renderChips(classes: Record<any, string>) {
@@ -527,7 +530,8 @@ class MultiSelectAutoComplete<T> extends React.Component<MultiSelectAutoComplete
       return null;
     }
 
-    const endAdornment = this.props.endAdornment ? <InputAdornment position='end' classes={{root: classes.inputAdornmentRoot}}>{this.props.endAdornment}</InputAdornment> : undefined;
+    const startAdornment = this.props.startAdornment ? <InputAdornment position='start' classes={{root: classes.inputAdornmentRoot}}>{this.props.startAdornment}</InputAdornment> : undefined;
+    const endAdornment   = this.props.endAdornment ? <InputAdornment position='end' classes={{root: classes.inputAdornmentRoot}}>{this.props.endAdornment}</InputAdornment> : undefined;
 
     return (
       <Downshift
@@ -554,15 +558,16 @@ class MultiSelectAutoComplete<T> extends React.Component<MultiSelectAutoComplete
                 getInputProps({
                   disabled: disabled,
                   onKeyDown: this.handleKeyDown,
+                  onFocus: this.handleFocus,
                   autoFocus: autoFocus,
                   label: label,
                   placeholder: placeholder,
                 }),
                 {
                   align: align,
-                  variant,
+                  variant: variant,
                   disableErrors: disableErrors,
-                  startAdornment: this.renderChips(classes),
+                  startAdornment: (< >{startAdornment}{this.renderChips(classes)}</>),
                   endAdornment: endAdornment
                 },
                 (node => {

--- a/packages/rewire-ui/src/components/NumberField.tsx
+++ b/packages/rewire-ui/src/components/NumberField.tsx
@@ -171,7 +171,7 @@ class NumberTextField extends React.Component<NumberFieldProps> {
           isNumericString={this.props.isNumericString}
           inputProps={{spellCheck: false, className: this.props.classes.nativeInput, style: {textAlign: this.props.align || 'left'}}}
           InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: this.props.classes.inputRoot, input: inputClassName, formControl: inputFormControlClassName}}}
-          InputLabelProps={{shrink: true, classes: {root: this.props.classes.inputLabelRoot, outlined: this.props.classes.inputLabelOutlined}}}
+          InputLabelProps={{shrink: true, classes: {root: this.props.classes.inputLabelRoot, outlined: this.props.classes.inputLabelOutlined, shrink: this.props.classes.inputLabelShrink}}}
           FormHelperTextProps={{classes: {root: this.props.classes.helperTextRoot, contained: this.props.classes.helperTextContained}}}
           customInput={TextField}
           placeholder={this.props.placeholder}
@@ -206,7 +206,7 @@ class NumberTextField extends React.Component<NumberFieldProps> {
             isNumericString={props.isNumericString}
             inputProps={{spellCheck: false, className: props.classes.nativeInput, style: {textAlign: props.align || 'left'}}}
             InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: props.classes.inputRoot, input: inputClassName, formControl: inputFormControlClassName}}}
-            InputLabelProps={{shrink: true, classes: {root: props.classes.inputLabelRoot, outlined: props.classes.inputLabelOutlined}}}
+            InputLabelProps={{shrink: true, classes: {root: props.classes.inputLabelRoot, outlined: props.classes.inputLabelOutlined, shrink: props.classes.inputLabelShrink}}}
             FormHelperTextProps={{classes: {root: props.classes.helperTextRoot, contained: props.classes.helperTextContained}}}
             customInput={TextField}
             placeholder={props.placeholder}

--- a/packages/rewire-ui/src/components/PasswordField.tsx
+++ b/packages/rewire-ui/src/components/PasswordField.tsx
@@ -101,9 +101,12 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
   state: IPasswordFieldState = {
     showPassword: false,
   };
+  inputRef: React.RefObject<HTMLInputElement>;
 
   constructor(props: PasswordFieldPropsStyled) {
     super(props);
+
+    this.inputRef = React.createRef();
   }
 
   shouldComponentUpdate(nextProps: PasswordFieldPropsStyled, nextState: IPasswordFieldState) {
@@ -135,6 +138,7 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
 
   handleClickShowPassword = () => {
     this.setState(state => ({showPassword: !state.showPassword}));
+    this.inputRef.current && this.inputRef.current.focus();
   }
 
   render() {
@@ -173,6 +177,7 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
           error={!this.props.disableErrors && !this.props.disabled && !!this.props.error}
           helperText={!this.props.disableErrors && <span>{(!this.props.disabled && this.props.error) || ''}</span>}
           value={value}
+          inputRef={this.inputRef}
           autoFocus={this.props.autoFocus}
           onFocus={this.handleFocus}
           onBlur={this.props.onBlur}
@@ -180,7 +185,7 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
           onChange={(evt: React.ChangeEvent<HTMLInputElement>) => this.props.onValueChange(evt.target.value)}
           inputProps={{spellCheck: false, className: this.props.classes.nativeInput, style: {textAlign: this.props.align || 'left'}}}
           InputProps={{endAdornment: adornment, classes: {root: this.props.classes.inputRoot, input: inputClassName, inputType: this.props.classes.inputType, formControl: inputFormControlClassName}}}
-          InputLabelProps={{shrink: true, classes: {root: this.props.classes.inputLabelRoot, outlined: this.props.classes.inputLabelOutlined}}}
+          InputLabelProps={{shrink: true, classes: {root: this.props.classes.inputLabelRoot, outlined: this.props.classes.inputLabelOutlined, shrink: this.props.classes.inputLabelShrink}}}
           FormHelperTextProps={{classes: {root: this.props.classes.helperTextRoot, contained: this.props.classes.helperTextContained}}}
         />
       );
@@ -200,6 +205,7 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
             error={!props.disableErrors && !props.disabled && !!props.error}
             helperText={!props.disableErrors && <span>{(!props.disabled && props.error) || ''}</span>}
             value={props.value}
+            inputRef={this.inputRef}
             autoFocus={props.autoFocus}
             onFocus={this.handleFocus}
             onBlur={props.onBlur}
@@ -207,7 +213,7 @@ class PasswordFieldInternal extends React.Component<PasswordFieldPropsStyled, IP
             onChange={props.onChange}
             inputProps={{spellCheck: false, className: props.classes.nativeInput, style: {textAlign: props.align || 'left'}}}
             InputProps={{endAdornment: adornment, classes: {root: props.classes.inputRoot, input: inputClassName, inputType: props.classes.inputType, formControl: inputFormControlClassName}}}
-            InputLabelProps={{shrink: true, classes: {root: props.classes.inputLabelRoot, outlined: props.classes.inputLabelOutlined}}}
+            InputLabelProps={{shrink: true, classes: {root: props.classes.inputLabelRoot, outlined: props.classes.inputLabelOutlined, shrink: props.classes.inputLabelShrink}}}
             FormHelperTextProps={{classes: {root: props.classes.helperTextRoot, contained: props.classes.helperTextContained}}}
           />
         }

--- a/packages/rewire-ui/src/components/Select.tsx
+++ b/packages/rewire-ui/src/components/Select.tsx
@@ -390,7 +390,7 @@ class SelectInternal<T> extends React.Component<SelectInternalProps<T>, any> {
     let   cls   = (this.props.className || '') + ' select';
     return (
       <FormControl error={!disableErrors && !disabled && !!error} variant={variant} className={classNames(cls, classes.formControlRoot)}>
-        {label && <RootRef rootRef={this.InputLabelRef}><InputLabel htmlFor='name-error' shrink={true} classes={{root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}>{label}</InputLabel></RootRef>}
+        {label && <RootRef rootRef={this.InputLabelRef}><InputLabel htmlFor='name-error' shrink={true} classes={{root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined, shrink: classes.inputLabelShrink}}>{label}</InputLabel></RootRef>}
         {this.renderSelect(disabled, '', this.props.selectedItem, this.props.autoFocus, this.props.placeholder)}
         {!disableErrors && <FormHelperText classes={{root: classes.helperTextRoot, contained: classes.helperTextContained}}>{!disabled && error}</FormHelperText>}
       </FormControl>

--- a/packages/rewire-ui/src/components/TextField.tsx
+++ b/packages/rewire-ui/src/components/TextField.tsx
@@ -217,7 +217,7 @@ class TextFieldInternal extends React.Component<TextFieldPropsStyled> {
         onChange={(evt: React.ChangeEvent<HTMLInputElement>) => this.props.onValueChange(evt.target.value)}
         inputProps={{spellCheck: !!multiline, className: classes.nativeInput, style: {textAlign: this.props.align || 'left'}}}
         InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, multiline: multilineClassName, input: inputClassName, inputType: inputTypeClassName, formControl: inputFormControlClassName}}}
-        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
+        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined, shrink: classes.inputLabelShrink}}}
         FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
       />);
     }
@@ -246,7 +246,7 @@ class TextFieldInternal extends React.Component<TextFieldPropsStyled> {
           onChange={props.onChange}
           inputProps={{spellCheck: !!multiline, className: classes.nativeInput, style: {textAlign: props.align || 'left'}}}
           InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, multiline: multilineClassName, input: inputClassName, inputType: inputTypeClassName, formControl: inputFormControlClassName}}}
-          InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
+          InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined, shrink: classes.inputLabelShrink}}}
           FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
         />
       }

--- a/packages/rewire-ui/src/components/TimeInputField.tsx
+++ b/packages/rewire-ui/src/components/TimeInputField.tsx
@@ -281,7 +281,7 @@ class TimeInputField extends React.Component<TimeFieldProps, ITimeState> {
         variant={variant}
         inputProps={{spellCheck: false, className: classes.nativeInput, style: {textAlign: align || 'left'}}}
         InputProps={{startAdornment: startAdornment, endAdornment: endAdornment, classes: {root: classes.inputRoot, input: inputClassName, formControl: inputFormControlClassName}}}
-        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined}}}
+        InputLabelProps={{shrink: true, classes: {root: classes.inputLabelRoot, outlined: classes.inputLabelOutlined, shrink: classes.inputLabelShrink}}}
         FormHelperTextProps={{classes: {root: classes.helperTextRoot, contained: classes.helperTextContained}}}
       />);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,11 +2817,11 @@ component-emitter@^1.2.1:
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 compressible@~2.0.16:
-  version "2.0.16"
-  resolved "https://npm.worksight.services/compressible/-/compressible-2.0.16.tgz#a49bf9858f3821b64ce1be0296afc7380466a77f"
-  integrity sha512-JQfEOdnI7dASwCuSPWIeVYwc/zMsu/+tRhoUvEfXz2gxOA2DNjmG5vhtFdBlhWPPGo+RdT9S3tgc/uH5qgDiiA==
+  version "2.0.17"
+  resolved "https://npm.worksight.services/compressible/-/compressible-2.0.17.tgz#6e8c108a16ad58384a977f3a482ca20bff2f38c1"
+  integrity sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==
   dependencies:
-    mime-db ">= 1.38.0 < 2"
+    mime-db ">= 1.40.0 < 2"
 
 compression@^1.7.3:
   version "1.7.4"
@@ -2888,12 +2888,12 @@ conventional-changelog-angular@^5.0.3:
     q "^1.5.1"
 
 conventional-changelog-core@^3.1.6:
-  version "3.1.6"
-  resolved "https://npm.worksight.services/conventional-changelog-core/-/conventional-changelog-core-3.1.6.tgz#ac1731a461c50d150d29c1ad4f33143293bcd32f"
-  integrity sha512-5teTAZOtJ4HLR6384h50nPAaKdDr+IaU0rnD2Gg2C3MS7hKsEPH8pZxrDNqam9eOSPQg9tET6uZY79zzgSz+ig==
+  version "3.2.2"
+  resolved "https://npm.worksight.services/conventional-changelog-core/-/conventional-changelog-core-3.2.2.tgz#de41e6b4a71011a18bcee58e744f6f8f0e7c29c0"
+  integrity sha512-cssjAKajxaOX5LNAJLB+UOcoWjAIBvXtDMedv/58G+YEmAXMNfC16mmPl0JDOuVJVfIqM0nqQiZ8UCm8IXbE0g==
   dependencies:
-    conventional-changelog-writer "^4.0.3"
-    conventional-commits-parser "^3.0.1"
+    conventional-changelog-writer "^4.0.5"
+    conventional-commits-parser "^3.0.2"
     dateformat "^3.0.0"
     get-pkg-repo "^1.0.0"
     git-raw-commits "2.0.0"
@@ -2904,20 +2904,20 @@ conventional-changelog-core@^3.1.6:
     q "^1.5.1"
     read-pkg "^3.0.0"
     read-pkg-up "^3.0.0"
-    through2 "^2.0.0"
+    through2 "^3.0.0"
 
 conventional-changelog-preset-loader@^2.1.1:
   version "2.1.1"
   resolved "https://npm.worksight.services/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.1.1.tgz#65bb600547c56d5627d23135154bcd9a907668c4"
   integrity sha512-K4avzGMLm5Xw0Ek/6eE3vdOXkqnpf9ydb68XYmCc16cJ99XMMbc2oaNMuPwAsxVK6CC1yA4/I90EhmWNj0Q6HA==
 
-conventional-changelog-writer@^4.0.3:
-  version "4.0.3"
-  resolved "https://npm.worksight.services/conventional-changelog-writer/-/conventional-changelog-writer-4.0.3.tgz#916a2b302d0bb5ef18efd236a034c13fb273cde1"
-  integrity sha512-bIlpSiQtQZ1+nDVHEEh798Erj2jhN/wEjyw9sfxY9es6h7pREE5BNJjfv0hXGH/FTrAsEpHUq4xzK99eePpwuA==
+conventional-changelog-writer@^4.0.5:
+  version "4.0.5"
+  resolved "https://npm.worksight.services/conventional-changelog-writer/-/conventional-changelog-writer-4.0.5.tgz#fb9e384bb294e8e8a9f2568a3f4d1e11953d8641"
+  integrity sha512-g/Myp4MaJ1A+f7Ai+SnVhkcWtaHk6flw0SYN7A+vQ+MTu0+gSovQWs4Pg4NtcNUcIztYQ9YHsoxHP+GGQplI7Q==
   dependencies:
     compare-func "^1.3.1"
-    conventional-commits-filter "^2.0.1"
+    conventional-commits-filter "^2.0.2"
     dateformat "^3.0.0"
     handlebars "^4.1.0"
     json-stringify-safe "^5.0.1"
@@ -2925,15 +2925,7 @@ conventional-changelog-writer@^4.0.3:
     meow "^4.0.0"
     semver "^5.5.0"
     split "^1.0.0"
-    through2 "^2.0.0"
-
-conventional-commits-filter@^2.0.1:
-  version "2.0.1"
-  resolved "https://npm.worksight.services/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz#55a135de1802f6510b6758e0a6aa9e0b28618db3"
-  integrity sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==
-  dependencies:
-    is-subset "^0.1.1"
-    modify-values "^1.0.0"
+    through2 "^3.0.0"
 
 conventional-commits-filter@^2.0.2:
   version "2.0.2"
@@ -2942,19 +2934,6 @@ conventional-commits-filter@^2.0.2:
   dependencies:
     lodash.ismatch "^4.4.0"
     modify-values "^1.0.0"
-
-conventional-commits-parser@^3.0.1:
-  version "3.0.1"
-  resolved "https://npm.worksight.services/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz#fe1c49753df3f98edb2285a5e485e11ffa7f2e4c"
-  integrity sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==
-  dependencies:
-    JSONStream "^1.0.4"
-    is-text-path "^1.0.0"
-    lodash "^4.2.1"
-    meow "^4.0.0"
-    split2 "^2.0.0"
-    through2 "^2.0.0"
-    trim-off-newlines "^1.0.0"
 
 conventional-commits-parser@^3.0.2:
   version "3.0.2"
@@ -3455,9 +3434,9 @@ dot-prop@^4.1.1, dot-prop@^4.2.0:
     is-obj "^1.0.0"
 
 downshift@^3.2.7:
-  version "3.2.8"
-  resolved "https://npm.worksight.services/downshift/-/downshift-3.2.8.tgz#9fb20b2001a241357d7dc8c6e7f8dde6c20473b3"
-  integrity sha512-f36UiLKMJ8wLgyMQ6aBBLV9yDhWC6+DRUygmBQZIxx2Y5NabWbAH6xRgJTr6Gt4ww5aCVAonDJ9uMdmQLmRYUw==
+  version "3.2.10"
+  resolved "https://npm.worksight.services/downshift/-/downshift-3.2.10.tgz#00f8e50383199c3f07ce63b575a840e2918b7b9f"
+  integrity sha512-fEYNbV/qDLUHTxF9wALNe51Xe5zauUhy2sqgYG1CtmAfUFMI30UuSaisU8CD0DEsFSIsaEvsVgtabb6nTEhtaA==
   dependencies:
     "@babel/runtime" "^7.1.2"
     compute-scroll-into-view "^1.0.9"
@@ -3488,9 +3467,9 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.3.124, electron-to-chromium@^1.3.47:
-  version "1.3.125"
-  resolved "https://npm.worksight.services/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz#dbde0e95e64ebe322db0eca764d951f885a5aff2"
-  integrity sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==
+  version "1.3.126"
+  resolved "https://npm.worksight.services/electron-to-chromium/-/electron-to-chromium-1.3.126.tgz#39363f76e55cf2bc06cd919cb76c808b3acaed30"
+  integrity sha512-anr0OeQkZvOGzsz1ZM7BliJjHKfEsodQWoncklQWryDCSXMdVtt/fXlQBKfXXmbMVDhpiydwL3jaonbWuk/F6g==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -4577,11 +4556,6 @@ is-stream@^1.0.1, is-stream@^1.1.0:
   resolved "https://npm.worksight.services/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
-is-subset@^0.1.1:
-  version "0.1.1"
-  resolved "https://npm.worksight.services/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
-  integrity sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
-
 is-svg@^3.0.0:
   version "3.0.0"
   resolved "https://npm.worksight.services/is-svg/-/is-svg-3.0.0.tgz#9321dbd29c212e5ca99c4fa9794c714bcafa2f75"
@@ -5155,7 +5129,7 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-mime-db@1.40.0, "mime-db@>= 1.38.0 < 2":
+mime-db@1.40.0, "mime-db@>= 1.40.0 < 2":
   version "1.40.0"
   resolved "https://npm.worksight.services/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==


### PR DESCRIPTION
…If present, it appears at the beginning of the input, left of any chips of selected items for the input.

    - MultiSelectAutoComplete now re-focuses the input when mouse clicking to remove selectedItems.
    - AutoComplete now has a delete icon button on its input if it currently has a value and is being moused over or has focus. It is marked by an x icon, which when clicked, will clear the input, and then re-focus the input (formally clearing an autocomplete with a value was not possible).
    - Mouse clicking a password field's eye icon to show / hide the actual value of the password will now cause the input to be focused after, as opposed to just blurring the field.
- version updates with publish to npm