### PR TITLE
Rewire-grid: - GridModel now has a "commit" method, that will set the…

### DIFF
--- a/examples/src/HomeView.tsx
+++ b/examples/src/HomeView.tsx
@@ -247,7 +247,7 @@ function createTestGrid(nRows: number, nColumns: number) {
   // setTimeout(() => {
   //   grid.columnByPos(4).canSort = false;
   //   grid.columnByPos(5).editable = true;
-  //   grid.columnByPos(6).readOnly = true;
+    // grid.columnByPos(6).readOnly = true;
   //   grid.columnByPos(7).enabled = false;
   //   grid.columnByPos(8).enabled = false;
   //   grid.columnByPos(8).renderer = (cell) => <div>{cell.value + ' Col'}</div>;
@@ -261,7 +261,7 @@ function createTestGrid(nRows: number, nColumns: number) {
   // setTimeout(() => {
   //   grid.cellByPos(0, 7).align = '';
   //   grid.cellByPos(0, 7).enabled = false;
-  //   grid.cellByPos(0, 19).setValue(3);
+    // grid.cellByPos(0, 19).setValue(3);
   //   grid.cellByPos(0, 20).setValue(20);
   //   grid.clearSelection();
   // }, 5000);
@@ -280,8 +280,9 @@ newRow.data['column2']    = 'RC 2-3';
 newRow.data['column3']    = 'RC 3-3';
 newRow.data['timeColumn'] = '8:11';
 grid.addRow(newRow);
-
-grid.cell('3', 'column8')!.value = 'ooga booga boa';
+grid.cellByPos(0, 0)!.setValue('ooga booga boa');
+// grid.dataRowsByPosition.forEach(row => row.cellsByColumnPosition.forEach(cell => cell.row = row));
+grid.commit();
 // const r                          = grid.get();
 // console.log(r);
 // setTimeout(() => grid.rows.length = 0, 4000);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire",
-  "version": "1.0.50",
+  "version": "1.0.52",
   "description": "WorkSight .NEXT core",
   "main": "src/index.js",
   "private": true,

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.50",
+  "version": "1.0.52",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.50",
+  "version": "1.0.52",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.50",
+  "version": "1.0.52",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.50",
+  "version": "1.0.52",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-grid/src/components/Grid.tsx
+++ b/packages/rewire-grid/src/components/Grid.tsx
@@ -384,8 +384,7 @@ const GridInternal = withStyles(styles, class extends React.PureComponent<GridPr
 
   constructor(props: GridProps) {
     super(props);
-    this.grid = props.grid;
-    this.grid.originalDataRowsByPosition = this.grid.dataRowsByPosition.slice();
+    this.grid              = props.grid;
     this._rowElements      = {};
     this._fixedRowElements = {};
 
@@ -405,8 +404,6 @@ const GridInternal = withStyles(styles, class extends React.PureComponent<GridPr
       watch(_currentWindowSize, () => this.updateForScrollbars());
 
       watch(() => this.grid.dataRowsByPosition.length, () => {
-        this.grid.changed = this.grid.hasChanges();
-        this.grid.inError = this.grid.hasErrors();
         setTimeout(() => this.updateForScrollbars(), 0);
       });
     });

--- a/packages/rewire-grid/src/components/Row.tsx
+++ b/packages/rewire-grid/src/components/Row.tsx
@@ -5,7 +5,6 @@ import {
   IGroupRow,
   getValue,
   isGroupRow,
-  cloneValue,
 }                              from '../models/GridTypes';
 import * as React              from 'react';
 import ResizeObserver          from 'resize-observer-polyfill';
@@ -65,10 +64,6 @@ const Row = withStyles(styles, class extends PureComponent<RowProps, {}> {
 
   constructor(props: RowProps) {
     super(props);
-    let row = props.row;
-    Object.keys(row.cells).forEach(columnName => {
-      row.originalData[columnName] = cloneValue(row.cells[columnName].value);
-    });
   }
 
   componentWillUnmount() {

--- a/packages/rewire-grid/src/models/GridTypes.ts
+++ b/packages/rewire-grid/src/models/GridTypes.ts
@@ -154,6 +154,8 @@ export interface IGrid extends IRows, IDisposable {
   get(): ICellDataMap[];
   getChanges(): ICellDataMap[];
   set(data: (IRowData | undefined)[]): void;
+  _commit(): void;
+  commit(): void;
 
   addColumn(column: IColumn): IColumn;
   setColumnPositions(): void;
@@ -258,6 +260,7 @@ export interface IRow extends IDisposable {
   getErrors(): IErrorData[];
   createCell(column: IColumn, value: any, type?: string): ICell;
   clear(columnNames?: string[]): void;
+  commit(): void;
   _setValue(data: ICellDataMap, triggerOnValueChangeHandler?: boolean): boolean;
   setValue(data: ICellDataMap, triggerOnValueChangeHandler?: boolean): boolean;
   mergeAllColumns(): void;

--- a/packages/rewire-grid/src/models/RowModel.ts
+++ b/packages/rewire-grid/src/models/RowModel.ts
@@ -78,6 +78,8 @@ export class RowModel implements IRow, IDisposable {
     if (!this.grid.loading) {
       this.mergeAllColumns();
     }
+
+    this.commit();
   }
 
   set parentRow(groupRow: IGroupRow | undefined) {
@@ -232,6 +234,14 @@ export class RowModel implements IRow, IDisposable {
     this.setValue(rowData);
   }
 
+  commit() {
+    Object.keys(this.cells).forEach(columnName => {
+      let clonedValue                                     = cloneValue(this.cells[columnName].value);
+      this.originalData[columnName]                       = clonedValue;
+      this.cells[columnName].row.originalData[columnName] = clonedValue; // Shouldn't need to do this, but again, some bug causing an issue.
+    });
+  }
+
   _setValue(data: ICellDataMap, triggerOnValueChangeHandler: boolean = true): boolean {
     if (!data) return false;
     let success = false;
@@ -372,6 +382,7 @@ export default function create(grid: IGrid, rows: IRow[], data?: IRowData, posit
   } else {
     grid.dataRowsByPosition.splice(r.position, 0, r);
   }
+
   return r;
 }
 

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.50",
+  "version": "1.0.52",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,9 +1411,9 @@
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
 "@octokit/endpoint@^5.1.0":
-  version "5.1.2"
-  resolved "https://npm.worksight.services/@octokit%2fendpoint/-/endpoint-5.1.2.tgz#45fd879e33a25ee10fa4cffc4d098ee04135afe6"
-  integrity sha512-bBGGmcRFq1x0jrB29G/9KjYmO3cdHfk3476B2JOHRvLsNw1Pn3l+ZvbiqtcO9qAS4Ti+zFedLB84ziHZRZclQA==
+  version "5.1.3"
+  resolved "https://npm.worksight.services/@octokit%2fendpoint/-/endpoint-5.1.3.tgz#b503e56c74663a601e6e03c8eb6d143f4653d34d"
+  integrity sha512-ePx9kcUo0agRk0HaXhl+pKMXpBH1O3CAygwWIh7GT5i5kcUr8QowS0GBaZPirr1e0PqaFYr41hQfcUBA1R5AEQ==
   dependencies:
     deepmerge "3.2.0"
     is-plain-object "^3.0.0"
@@ -1447,9 +1447,9 @@
     universal-user-agent "^2.1.0"
 
 "@octokit/rest@^16.16.0":
-  version "16.26.0"
-  resolved "https://npm.worksight.services/@octokit%2frest/-/rest-16.26.0.tgz#5c12b28763219045e1c9a15182e8dfaed10004e8"
-  integrity sha512-NBpzre44ZAQWZhlH+zUYTgqI0pHN+c9rNj4d+pCydGEiKTGc1HKmoTghEUyr9GxazDyoAvmpx9nL0I7QS1Olvg==
+  version "16.27.0"
+  resolved "https://npm.worksight.services/@octokit%2frest/-/rest-16.27.0.tgz#6c2d1cba3efb8866ef2741c64d23b8f257c9dc89"
+  integrity sha512-UvCxVOCfHzEhOaltSKQBy81kMqQ+hglF3rAR4STut4WWr2tXvVnrIkGxeblO0TvmTt5zuxfgQfgG5kAHUT44RA==
   dependencies:
     "@octokit/request" "^4.0.1"
     "@octokit/request-error" "^1.0.2"
@@ -2439,9 +2439,9 @@ binary-extensions@^1.0.0:
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
 bluebird@^3.5.1, bluebird@^3.5.3:
-  version "3.5.4"
-  resolved "https://npm.worksight.services/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
-  integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
+  version "3.5.5"
+  resolved "https://npm.worksight.services/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
 
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
… current state of the grid to be the base state, making the grid be in a "not changed" state, and making any future reverts revert to that state. To facilitate the above change, a "commit" method was added to the RowModel as well.

    - The GridModel "set" method now acts like a setting the grid data for the first time, so a commit is triggered at the end of this method.
    - Grid and row original data is now set during creation and on commit, and no longer set during renders of the Grid // Row. If rows are added // deleted or cell values are changed after the grid is created or "set, and this state is intended to be the base state, the commit method will need to be called.
    - The lingering issue of grid model row references and cell model row references not being in sync even though they refer to the same row, has reared its ugly head yet again. The Row "commit" method has an extra line of code because of this bug. No fix for it as of yet.