### PR TITLE
rewire-grid: - GridModel revert will now properly validate the grid a…

### DIFF
--- a/examples/src/HomeView.tsx
+++ b/examples/src/HomeView.tsx
@@ -246,8 +246,8 @@ function createTestGrid(nRows: number, nColumns: number) {
   let grid = createGrid(rows, cols, { groupBy: ['column2', 'column3'], toggleableColumns: ['column8', 'column9'], multiSelect: true, allowMergeColumns: true });
 
   grid.addFixedRow({ data: { column5: '2017', column6: '2018' } });
-  setTimeout(() => {cols[28].fixed = true; }, 3000);
-  setTimeout(() => {cols[28].fixed = false; }, 6000);
+  // setTimeout(() => {cols[28].fixed = true; }, 3000);
+  // setTimeout(() => {cols[28].fixed = false; }, 6000);
   // sort first by  column7 then by column6
   // grid.addSort(cols[7], 'ascending')
   //     .addSort(cols[6], 'descending');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire",
-  "version": "1.0.110",
+  "version": "1.0.111",
   "description": "WorkSight .NEXT core",
   "main": "src/index.js",
   "private": true,

--- a/packages/rewire-common/package.json
+++ b/packages/rewire-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-common",
-  "version": "1.0.110",
+  "version": "1.0.111",
   "description": "Common utilities used by the rewire suite of reactive components",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-core/package.json
+++ b/packages/rewire-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-core",
-  "version": "1.0.110",
+  "version": "1.0.111",
   "description": "A simple library for developing react applications using reactive state and proxies",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-graphql/package.json
+++ b/packages/rewire-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-graphql",
-  "version": "1.0.110",
+  "version": "1.0.111",
   "description": "A reactive observable cache for graphql built using rewire-core.",
   "main": "./src/index.ts",
   "typings": "./src/index.ts",

--- a/packages/rewire-grid/package.json
+++ b/packages/rewire-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-grid",
-  "version": "1.0.110",
+  "version": "1.0.111",
   "description": "A lightweight reactive grid implementation built using rewire-core.",
   "repository": {
     "type": "git",

--- a/packages/rewire-grid/src/components/Cell.tsx
+++ b/packages/rewire-grid/src/components/Cell.tsx
@@ -329,56 +329,55 @@ class Cell extends React.PureComponent<CellProps, {}> {
     }
   }
 
-  renderCell() {
-    let cell = this.cell;
-    if (cell.editing) {
-      let Editor = this.column.editor;
-      if (!Editor) return;
-      let cellType              = this.column.type;
-      let additionalProps       = {};
-      let endOfTextOnFocus      = false;
-      let selectOnFocus         = true;
-      let cursorPositionOnFocus = undefined;
-      let value                 = cell.value;
-      if (this.cell.keyForEdit) {
-        value            = cell.keyForEdit;
-        endOfTextOnFocus = true;
-        selectOnFocus    = false;
-        if (cellType === 'number') {
-          endOfTextOnFocus      = false;
-          cursorPositionOnFocus = 1;
+  renderCell = React.memo((): JSX.Element | null => {
+    return <Observe render={() => {
+      let cell = this.cell;
+      if (cell.editing) {
+        let Editor = this.column.editor;
+        if (!Editor) return null;
+        let cellType              = this.column.type;
+        let additionalProps       = {};
+        let endOfTextOnFocus      = false;
+        let selectOnFocus         = true;
+        let cursorPositionOnFocus = undefined;
+        let value                 = cell.value;
+        if (this.cell.keyForEdit) {
+          value            = cell.keyForEdit;
+          endOfTextOnFocus = true;
+          selectOnFocus    = false;
+          if (cellType === 'number') {
+            endOfTextOnFocus      = false;
+            cursorPositionOnFocus = 1;
+          }
+          if (cellType === 'auto-complete' || cellType === 'multiselectautocomplete') {
+            value                                = undefined;
+            additionalProps['initialInputValue'] = cell.keyForEdit;
+          }
         }
+        let editorClasses = undefined;
+        if (cellType === 'select' || cellType === 'multiselect') {
+          editorClasses = {inputRoot: this.props.classes.editorSelectInputRoot, select: this.props.classes.editorSelectSelect};
+        } else if (cellType === 'checked') {
+          editorClasses = {checkboxRoot: this.props.classes.editorCheckboxRoot};
+        } else if (cellType === 'text' || cellType === 'date' || cellType === 'email' || cellType === 'password' || cellType === 'time' || cellType === 'number' || cellType === 'phone' || cellType === 'auto-complete' || 'mask') {
+          editorClasses = {formControlRoot: this.props.classes.editorFormControlRoot, inputRoot: this.props.classes.editorInputRoot};
+        }
+
         if (cellType === 'auto-complete' || cellType === 'multiselectautocomplete') {
-          value                                = undefined;
-          additionalProps['initialInputValue'] = cell.keyForEdit;
+          Object.assign(editorClasses, {container: this.props.classes.editorAutoCompleteContainer});
         }
-      }
-      let editorClasses = undefined;
-      if (cellType === 'select' || cellType === 'multiselect') {
-        editorClasses = {inputRoot: this.props.classes.editorSelectInputRoot, select: this.props.classes.editorSelectSelect};
-      } else if (cellType === 'checked') {
-        editorClasses = {checkboxRoot: this.props.classes.editorCheckboxRoot};
-      } else if (cellType === 'text' || cellType === 'date' || cellType === 'email' || cellType === 'password' || cellType === 'time' || cellType === 'number' || cellType === 'phone' || cellType === 'auto-complete' || 'mask') {
-        editorClasses = {formControlRoot: this.props.classes.editorFormControlRoot, inputRoot: this.props.classes.editorInputRoot};
-      }
 
-      if (cellType === 'auto-complete' || cellType === 'multiselectautocomplete') {
-        Object.assign(editorClasses, {container: this.props.classes.editorAutoCompleteContainer});
+        const height = (this.cell as CellModel).element!.getBoundingClientRect().height - 2;
+        return <Observe render={() => (
+          <div className={this.props.classes.editorContainer} style={{height}}>
+            <Editor field={{...cell, value: value, autoFocus: true, align: cell.align, error: undefined, disableErrors: true}} endOfTextOnFocus={endOfTextOnFocus} selectOnFocus={selectOnFocus} cursorPositionOnFocus={cursorPositionOnFocus} className={cell.cls} onValueChange={this.onValueChange} classes={editorClasses} {...additionalProps}/>
+          </div>
+        )} />;
       }
 
-      const height = (this.cell as CellModel).element!.getBoundingClientRect().height;
-      return (
-        <div className={this.props.classes.editorContainer} style={{height}}>
-          <Editor field={{...cell, value: value, autoFocus: true, align: cell.align, error: undefined, disableErrors: true}} endOfTextOnFocus={endOfTextOnFocus} selectOnFocus={selectOnFocus} cursorPositionOnFocus={cursorPositionOnFocus} className={cell.cls} onValueChange={this.onValueChange} classes={editorClasses} {...additionalProps}/>
-        </div>
-      );
-    }
-
-    return <Observe render={
-      () => {
+      return <Observe render={() => {
         let hasError = !!cell.error;
         let value    = !isNullOrUndefinedOrEmpty(this.value) ? this.value : <span>&nbsp;</span>;
-
         return (
           < >
             {cell.renderer
@@ -392,9 +391,9 @@ class Cell extends React.PureComponent<CellProps, {}> {
             {hasError && this.renderErrorIcon()}
           </>
         );
-      }
-    } />;
-  }
+      }} />;
+    }} />;
+  });
 
   render() {
     const {classes} = this.props;
@@ -441,7 +440,7 @@ class Cell extends React.PureComponent<CellProps, {}> {
       let innerCell =
         <div className={classNames(classes.cellContainer, 'cellContainer')}>
           <div className={cellInnerContainerClasses}>
-            {this.renderCell()}
+            <this.renderCell />
           </div>
         </div>;
       let cellContent = innerCell;

--- a/packages/rewire-grid/src/components/Row.tsx
+++ b/packages/rewire-grid/src/components/Row.tsx
@@ -138,18 +138,20 @@ class InternalRow extends PureComponent<RowProps, {}> {
     removeElement(this.props.row, this);
   }
 
-  renderCells = () => {
-    if (!this.props.row.cells) return [];
+  renderCells = React.memo((): JSX.Element | null => {
+    return <Observe render={() => {
+      if (!this.props.row.cells) return null;
 
-    let cells: JSX.Element[] = [];
-    this.props.columns.forEach((column: IColumn) => {
-      let cell = this.props.row.cells[column.name];
-      let Cell = this.props.Cell;
-      if ((cell.colSpan ===  0) || (cell.rowSpan === 0)) return;
-        cells.push(<Cell key={cell.id} cell={cell} onClick={this.handleRowClick} />);
-    });
-    return <Observe render={() => cells} />;
-  }
+      let cells: JSX.Element[] = [];
+      this.props.columns.forEach((column: IColumn) => {
+        let cell = this.props.row.cells[column.name];
+        let Cell = this.props.Cell;
+        if ((cell.colSpan ===  0) || (cell.rowSpan === 0)) return;
+          cells.push(<Cell key={cell.id} cell={cell} onClick={this.handleRowClick} />);
+      });
+      return cells;
+    }} />;
+  });
 
   calculateInitialHeight() {
     const components = getComponents(this.props.row);
@@ -197,7 +199,7 @@ class InternalRow extends PureComponent<RowProps, {}> {
         const className = cc([this.props.className, {selected: this.props.row.selected}, (this.props.row.visible === false) ?  this.props.classes.hidden : this.props.classes.visible, this.props.row.cls, 'tabrow']);
         return <Observe render={() => (
           <tr className={className} ref={this.element} onClick={this.handleRowClick}>
-            {this.renderCells()}
+            <this.renderCells />
           </tr>
         )} />;
       }

--- a/packages/rewire-grid/src/models/GridModel.ts
+++ b/packages/rewire-grid/src/models/GridModel.ts
@@ -204,6 +204,7 @@ class GridModel implements IGrid, IDisposable {
   revert(): void {
     if (this.__changeTracker) {
       this.__changeTracker.revert();
+      this.validate();
       this.mergeColumns();
     }
   }
@@ -975,35 +976,37 @@ class GridModel implements IGrid, IDisposable {
 
   updateCellSelectionProperties(cellsToSelect: ICell[]) {
     cellsToSelect.forEach(cell => {
-      let adjacentTopCell = this.adjacentTopCell(cell);
-      let sameGroupTop    = !!adjacentTopCell && true; // (adjacentTopCell.row.parentRow && adjacentTopCell.row.parentRow.id) === (cell.row.parentRow && cell.row.parentRow.id);
-      if (!adjacentTopCell || !sameGroupTop || !adjacentTopCell.selected) {
-        cell.isTopMostSelection = true;
-      } else {
-        cell.isTopMostSelection = false;
-      }
+      freeze(() => {
+        let adjacentTopCell = this.adjacentTopCell(cell);
+        let sameGroupTop    = !!adjacentTopCell && true; // (adjacentTopCell.row.parentRow && adjacentTopCell.row.parentRow.id) === (cell.row.parentRow && cell.row.parentRow.id);
+        if (!adjacentTopCell || !sameGroupTop || !adjacentTopCell.selected) {
+          cell.isTopMostSelection = true;
+        } else {
+          cell.isTopMostSelection = false;
+        }
 
-      let adjacentRightCell = this.adjacentRightCell(cell);
-      if (!adjacentRightCell || !adjacentRightCell.selected) {
-        cell.isRightMostSelection = true;
-      } else {
-        cell.isRightMostSelection = false;
-      }
+        let adjacentRightCell = this.adjacentRightCell(cell);
+        if (!adjacentRightCell || !adjacentRightCell.selected) {
+          cell.isRightMostSelection = true;
+        } else {
+          cell.isRightMostSelection = false;
+        }
 
-      let adjacentBottomCell = this.adjacentBottomCell(cell);
-      let sameGroupBottom    = !!adjacentBottomCell && true; // (adjacentBottomCell.row.parentRow && adjacentBottomCell.row.parentRow.id) === (cell.row.parentRow && cell.row.parentRow.id);
-      if (!adjacentBottomCell || !sameGroupBottom || !adjacentBottomCell.selected) {
-        cell.isBottomMostSelection = true;
-      } else {
-        cell.isBottomMostSelection = false;
-      }
+        let adjacentBottomCell = this.adjacentBottomCell(cell);
+        let sameGroupBottom    = !!adjacentBottomCell && true; // (adjacentBottomCell.row.parentRow && adjacentBottomCell.row.parentRow.id) === (cell.row.parentRow && cell.row.parentRow.id);
+        if (!adjacentBottomCell || !sameGroupBottom || !adjacentBottomCell.selected) {
+          cell.isBottomMostSelection = true;
+        } else {
+          cell.isBottomMostSelection = false;
+        }
 
-      let adjacentLeftCell = this.adjacentLeftCell(cell);
-      if (!adjacentLeftCell || !adjacentLeftCell.selected) {
-        cell.isLeftMostSelection = true;
-      } else {
-        cell.isLeftMostSelection = false;
-      }
+        let adjacentLeftCell = this.adjacentLeftCell(cell);
+        if (!adjacentLeftCell || !adjacentLeftCell.selected) {
+          cell.isLeftMostSelection = true;
+        } else {
+          cell.isLeftMostSelection = false;
+        }
+      });
     });
   }
 

--- a/packages/rewire-ui/package.json
+++ b/packages/rewire-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewire-ui",
-  "version": "1.0.110",
+  "version": "1.0.111",
   "description": "A lightweight set of material-ui-next components built using the reactive library rewire-core.",
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,9 +731,9 @@
     safe-buffer "^5.1.2"
 
 "@evocateur/pacote@^9.6.0":
-  version "9.6.2"
-  resolved "https://npm.worksight.services/@evocateur%2fpacote/-/pacote-9.6.2.tgz#cb70ef1e53430945c5f595a76cac38a1ce727ef5"
-  integrity sha512-llHPpyboLDCfrqninUglXqbQc2TblQjVJbqluOmWoudj86Xrhz658wqUFpRJ3IXR+K7lgACFK5ypzVB9EMNMtg==
+  version "9.6.3"
+  resolved "https://npm.worksight.services/@evocateur%2fpacote/-/pacote-9.6.3.tgz#bcd7adbd3c2ef303aa89bd24166f06dd9c080d89"
+  integrity sha512-ExqNqcbdHQprEgKnY/uQz7WRtyHRbQxRl4JnVkSkmtF8qffRrF9K+piZKNLNSkRMOT/3H0e3IP44QVCHaXMWOQ==
   dependencies:
     "@evocateur/npm-registry-fetch" "^4.0.0"
     bluebird "^3.5.3"
@@ -1445,9 +1445,9 @@
     write-file-atomic "^2.3.0"
 
 "@material-ui/core@^4.2.0":
-  version "4.2.0"
-  resolved "https://npm.worksight.services/@material-ui%2fcore/-/core-4.2.0.tgz#fd57352c63a50bc28d8b0d61a779a55aba84f9c4"
-  integrity sha512-kqwoCMpGaj3zJedihUuVZWjISh+T72KAXOwgk6VKNf+APMTB8yLByLSgSLDhXsliRBO/9Pda/0g/KzGY7R+irQ==
+  version "4.2.1"
+  resolved "https://npm.worksight.services/@material-ui%2fcore/-/core-4.2.1.tgz#18255c01d039ff856bfdb2f955fec6c9ae64a464"
+  integrity sha512-hasPQUFAb9OxKng7UX2+SjUWtVZbnkVJ/jHZWXTivVcU+UzvNIpA9AyRRQvZ8SPV6swP/HD2VzUBzoMEeRR6wg==
   dependencies:
     "@babel/runtime" "^7.2.0"
     "@material-ui/styles" "^4.2.0"
@@ -1456,8 +1456,8 @@
     "@material-ui/utils" "^4.1.0"
     "@types/react-transition-group" "^2.0.16"
     clsx "^1.0.2"
-    convert-css-length "^2.0.0"
-    deepmerge "^3.0.0"
+    convert-css-length "^2.0.1"
+    deepmerge "^4.0.0"
     hoist-non-react-statics "^3.2.1"
     is-plain-object "^3.0.0"
     normalize-scroll-left "^0.2.0"
@@ -1474,9 +1474,9 @@
     "@babel/runtime" "^7.2.0"
 
 "@material-ui/styles@^4.1.2", "@material-ui/styles@^4.2.0":
-  version "4.2.0"
-  resolved "https://npm.worksight.services/@material-ui%2fstyles/-/styles-4.2.0.tgz#dafb8a271cb6772354aece15d3e43af33844f692"
-  integrity sha512-VpPCNWYK1KjpurFh1gH02xpAmCqKZrC/rmiBosZcCRDl8AOcUkSxBMNU0rziHgSQ/jYTEh3MdKNs3Gq0vGCQ/w==
+  version "4.2.1"
+  resolved "https://npm.worksight.services/@material-ui%2fstyles/-/styles-4.2.1.tgz#b07383ffeaa840bcb6969eb17c5f0e3b734e8e5b"
+  integrity sha512-1KSOZ17LBWBqIyPRsEpyb4snT/wRIfQTPi0x66UvSzznVK9MPAfJx3/s5lVT4vrGFObs/nj6Pet6Nhrdl2WCrg==
   dependencies:
     "@babel/runtime" "^7.2.0"
     "@emotion/hash" "^0.7.1"
@@ -1484,7 +1484,7 @@
     "@material-ui/utils" "^4.1.0"
     clsx "^1.0.2"
     csstype "^2.5.2"
-    deepmerge "^3.0.0"
+    deepmerge "^4.0.0"
     hoist-non-react-statics "^3.2.1"
     jss "10.0.0-alpha.17"
     jss-plugin-camel-case "10.0.0-alpha.17"
@@ -1498,12 +1498,12 @@
     warning "^4.0.1"
 
 "@material-ui/system@^4.3.0":
-  version "4.3.0"
-  resolved "https://npm.worksight.services/@material-ui%2fsystem/-/system-4.3.0.tgz#6812049bf9257f8936c5de8f18b7142a67048247"
-  integrity sha512-VQh3mWZSmzm1JR7Ci35AHKwOhhxHHMrBWCdP4mh7UAwSdjWBE6s2Y9Y0iJiqMoEsHP64vU3W1JpsW2AgkUeHsQ==
+  version "4.3.1"
+  resolved "https://npm.worksight.services/@material-ui%2fsystem/-/system-4.3.1.tgz#5fe508d4ca94cdf1d76f7fe535413fcc949b23d9"
+  integrity sha512-Krrc/p/A3rod4M3FYcsWSqE5KxpoyMzYuUHhs0Pns3KH+5kcFyBU+aYbIzMfUz58rhbHkqrShf1fjj7EKcgY0g==
   dependencies:
     "@babel/runtime" "^7.2.0"
-    deepmerge "^3.0.0"
+    deepmerge "^4.0.0"
     prop-types "^15.7.2"
     warning "^4.0.1"
 
@@ -1743,9 +1743,9 @@
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
 "@types/node@*":
-  version "12.6.5"
-  resolved "https://npm.worksight.services/@types%2fnode/-/node-12.6.5.tgz#716f6b4258d04c0439e19b35b33242d431603368"
-  integrity sha512-8IUaNE8dbiVyv6wdi3mgrxZ9IYfDaulRY8A2MKiDugYj/tjPz/+JdwuC/uuBlGb+yTapiTratHfksPCy8trPQg==
+  version "12.6.6"
+  resolved "https://npm.worksight.services/@types%2fnode/-/node-12.6.6.tgz#831587377c35bb28fa33b6fe5f849a26a3f4a412"
+  integrity sha512-SMgj3x28MkJyHdWaMv/g/ca3LYDi5gR7O8mX0VKazvFOnmlDXctSEdd/8jfSqozjKFK1R9If1QZWkafX7yQTpA==
 
 "@types/node@^11.11.3":
   version "11.13.17"
@@ -3178,7 +3178,7 @@ conventional-recommended-bump@^4.0.4:
     meow "^4.0.0"
     q "^1.5.1"
 
-convert-css-length@^2.0.0:
+convert-css-length@^2.0.1:
   version "2.0.1"
   resolved "https://npm.worksight.services/convert-css-length/-/convert-css-length-2.0.1.tgz#90a76bde5bfd24d72881a5b45d02249b2c1d257c"
   integrity sha512-iGpbcvhLPRKUbBc0Quxx7w/bV14AC3ItuBEGMahA5WTYqB8lq9jH0kTXFheCBASsYnqeMFZhiTruNxr1N59Axg==
@@ -3500,12 +3500,12 @@ deep-eql@^3.0.1:
   dependencies:
     type-detect "^4.0.0"
 
-deepmerge@*, deepmerge@4.0.0:
+deepmerge@*, deepmerge@4.0.0, deepmerge@^4.0.0:
   version "4.0.0"
   resolved "https://npm.worksight.services/deepmerge/-/deepmerge-4.0.0.tgz#3e3110ca29205f120d7cb064960a39c3d2087c09"
   integrity sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==
 
-deepmerge@^3.0.0, deepmerge@^3.2.0:
+deepmerge@^3.2.0:
   version "3.3.0"
   resolved "https://npm.worksight.services/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
   integrity sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==
@@ -3663,9 +3663,9 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.3.191, electron-to-chromium@^1.3.47:
-  version "1.3.192"
-  resolved "https://npm.worksight.services/electron-to-chromium/-/electron-to-chromium-1.3.192.tgz#28721072385e48525a948f4297824ddb4bf1f75f"
-  integrity sha512-JkkpGlrilP1s/aFanueYZWf/DFDJaYgo3ZeamzgL5Drb70KQrVQRIPBq5vBN8sSRoKeZZak3aFJ83YtwsZgeEg==
+  version "1.3.193"
+  resolved "https://npm.worksight.services/electron-to-chromium/-/electron-to-chromium-1.3.193.tgz#de9b89959288070bffb14557daf8cf9f75b2caf8"
+  integrity sha512-WX01CG1UoPtTUFaKKwMn+u8nJ63loP6hNxePWtk1pN8ibWMyX1q6TiWPsz1ABBKXezvmaIdtP+0BwzjC1wyCaw==
 
 emoji-regex@^7.0.1:
   version "7.0.3"


### PR DESCRIPTION
…fter its values have been reverted. Ideally this would happen in the setRows method, but doesn't work due to freeze, so it is happening in the revert method, which is the only method that causes setRows to be called at the moment;

    - cell rendering performance improvement. Will no longer re-render inner cell contents when selecting cells.